### PR TITLE
Elevation compat

### DIFF
--- a/MaterialLibrary/src/main/java/io/doist/material/drawable/LayerMaterialDrawable.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/drawable/LayerMaterialDrawable.java
@@ -283,7 +283,8 @@ public class LayerMaterialDrawable extends LayerDrawable {
             return super.getIntrinsicWidth();
         }
     }
-     public int getIntrinsicWidthCompat() {
+
+    public int getIntrinsicWidthCompat() {
         int width = -1;
 
         final int N = getNumberOfLayers();

--- a/MaterialLibrary/src/main/java/io/doist/material/drawable/TintDrawable.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/drawable/TintDrawable.java
@@ -83,11 +83,6 @@ public class TintDrawable extends WrapperDrawable {
     }
 
     @Override
-    public boolean setState(int[] stateSet) {
-        return super.setState(stateSet) | super.superSetState(getState());
-    }
-
-    @Override
     protected boolean onStateChange(int[] state) {
         if (mTintState.mTint != null) {
             mTintState.mTintUpdate = true;

--- a/MaterialLibrary/src/main/java/io/doist/material/drawable/TintDrawable.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/drawable/TintDrawable.java
@@ -83,6 +83,11 @@ public class TintDrawable extends WrapperDrawable {
     }
 
     @Override
+    public boolean setState(int[] stateSet) {
+        return super.setState(stateSet) | super.superSetState(getState());
+    }
+
+    @Override
     protected boolean onStateChange(int[] state) {
         if (mTintState.mTint != null) {
             mTintState.mTintUpdate = true;

--- a/MaterialLibrary/src/main/java/io/doist/material/drawable/WrapperDrawable.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/drawable/WrapperDrawable.java
@@ -4,6 +4,7 @@ import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 
 import android.annotation.TargetApi;
+import android.content.res.ColorStateList;
 import android.content.res.Resources;
 import android.graphics.Canvas;
 import android.graphics.ColorFilter;
@@ -22,7 +23,15 @@ public class WrapperDrawable extends Drawable implements Drawable.Callback {
 
     public WrapperDrawable(Drawable drawable) {
         mWrapperState = createConstantState(null);
+        setWrappedDrawable(drawable);
+    }
+
+    public void setWrappedDrawable(Drawable drawable) {
         mWrapperState.setDrawable(drawable, this);
+    }
+
+    public Drawable getWrappedDrawable() {
+        return mWrapperState.mDrawable;
     }
 
     @Override
@@ -89,13 +98,31 @@ public class WrapperDrawable extends Drawable implements Drawable.Callback {
 
     @Override
     public boolean setState(int[] stateSet) {
-        return mWrapperState.mDrawable.setState(stateSet) |
-                super.setState(mWrapperState.mDrawable.getState());
+        return mWrapperState.mDrawable.setState(stateSet);
+    }
+
+    public boolean superSetState(int[] stateSet) {
+        return super.setState(stateSet);
+    }
+
+    @Override
+    public int[] getState() {
+        return mWrapperState.mDrawable.getState();
     }
 
     @Override
     protected boolean onStateChange(int[] state) {
         return false;
+    }
+
+    @Override
+    public void jumpToCurrentState() {
+        mWrapperState.mDrawable.jumpToCurrentState();
+    }
+
+    @Override
+    public Drawable getCurrent() {
+        return mWrapperState.mDrawable.getCurrent();
     }
 
     @Override
@@ -161,6 +188,40 @@ public class WrapperDrawable extends Drawable implements Drawable.Callback {
         return mWrapperState.mDrawable.getPadding(padding);
     }
 
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @Override
+    public void setTint(int tint) {
+        mWrapperState.mDrawable.setTint(tint);
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @Override
+    public void setTintList(ColorStateList tint) {
+        mWrapperState.mDrawable.setTintList(tint);
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @Override
+    public void setTintMode(PorterDuff.Mode tintMode) {
+        mWrapperState.mDrawable.setTintMode(tintMode);
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @Override
+    public void setHotspot(float x, float y) {
+        mWrapperState.mDrawable.setHotspot(x, y);
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @Override
+    public void setHotspotBounds(int left, int top, int right, int bottom) {
+        mWrapperState.mDrawable.setHotspotBounds(left, top, right, bottom);
+    }
+
+    /*
+     * Wrapper drawable state.
+     */
+
     @Override
     public Drawable mutate() {
         if (!mMutated && super.mutate() == this) {
@@ -198,6 +259,9 @@ public class WrapperDrawable extends Drawable implements Drawable.Callback {
         }
 
         public void setDrawable(Drawable drawable, WrapperDrawable owner) {
+            if (mDrawable != null) {
+                mDrawable.setCallback(null);
+            }
             mDrawable = drawable;
             mDrawable.setCallback(owner);
             mChildChangingConfigurations = mDrawable.getChangingConfigurations();
@@ -241,25 +305,16 @@ public class WrapperDrawable extends Drawable implements Drawable.Callback {
 
     @Override
     public void invalidateDrawable(Drawable who) {
-        final Callback callback = getCallback();
-        if (callback != null) {
-            callback.invalidateDrawable(this);
-        }
+        invalidateSelf();
     }
 
     @Override
     public void scheduleDrawable(Drawable who, Runnable what, long when) {
-        final Callback callback = getCallback();
-        if (callback != null) {
-            callback.scheduleDrawable(this, what, when);
-        }
+        scheduleSelf(what, when);
     }
 
     @Override
     public void unscheduleDrawable(Drawable who, Runnable what) {
-        final Callback callback = getCallback();
-        if (callback != null) {
-            callback.unscheduleDrawable(this, what);
-        }
+        unscheduleSelf(what);
     }
 }

--- a/MaterialLibrary/src/main/java/io/doist/material/drawable/WrapperDrawable.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/drawable/WrapperDrawable.java
@@ -27,6 +27,9 @@ public class WrapperDrawable extends Drawable implements Drawable.Callback {
     }
 
     public void setWrappedDrawable(Drawable drawable) {
+        if (mWrapperState.mDrawable != null) {
+            mWrapperState.mDrawable.setCallback(null);
+        }
         mWrapperState.setDrawable(drawable, this);
     }
 
@@ -259,9 +262,6 @@ public class WrapperDrawable extends Drawable implements Drawable.Callback {
         }
 
         public void setDrawable(Drawable drawable, WrapperDrawable owner) {
-            if (mDrawable != null) {
-                mDrawable.setCallback(null);
-            }
             mDrawable = drawable;
             mDrawable.setCallback(owner);
             mChildChangingConfigurations = mDrawable.getChangingConfigurations();

--- a/MaterialLibrary/src/main/java/io/doist/material/drawable/WrapperDrawable.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/drawable/WrapperDrawable.java
@@ -16,6 +16,7 @@ import android.os.Build;
 import android.util.AttributeSet;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 public class WrapperDrawable extends Drawable implements Drawable.Callback {
     private WrapperState mWrapperState;
@@ -101,11 +102,11 @@ public class WrapperDrawable extends Drawable implements Drawable.Callback {
 
     @Override
     public boolean setState(int[] stateSet) {
-        return mWrapperState.mDrawable.setState(stateSet);
-    }
-
-    public boolean superSetState(int[] stateSet) {
-        return super.setState(stateSet);
+        if (!Arrays.equals(getState(), stateSet)) {
+            boolean stateChanged = mWrapperState.mDrawable.setState(stateSet);
+            return onStateChange(stateSet) | stateChanged;
+        }
+        return false;
     }
 
     @Override

--- a/MaterialLibrary/src/main/java/io/doist/material/drawable/WrapperDrawable.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/drawable/WrapperDrawable.java
@@ -257,7 +257,7 @@ public class WrapperDrawable extends Drawable implements Drawable.Callback {
             if (state != null) {
                 mDrawable = state.mDrawable;
                 mChangingConfigurations = state.mChangingConfigurations;
-                mChildChangingConfigurations = state.mChildChangingConfigurations;;
+                mChildChangingConfigurations = state.mChildChangingConfigurations;
             }
         }
 

--- a/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationDelegate.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationDelegate.java
@@ -1,0 +1,318 @@
+package io.doist.material.elevation;
+
+import android.annotation.TargetApi;
+import android.content.res.TypedArray;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewGroup;
+
+import io.doist.material.R;
+
+/**
+ * Handles elevation drop shadows for a given view, similar to {@link View#setElevation(float)} on
+ * {@link Build.VERSION_CODES#LOLLIPOP} and above.
+ *
+ * Setup via {@link AttributeSet} or {@link #setElevation(float)}, {@link #setCornerRadius(float)} and
+ * {@link #setShownShadows(boolean, boolean, boolean, boolean)}.
+ *
+ * Your {@link View} must implement {@link Host} and proxy calls to {@link View#setBackground(Drawable)} to
+ * {@link #setBackground(Drawable)} and calls to {@link View#setPadding(int, int, int, int)} to
+ * {@link #setPadding(int, int, int, int)}. Ideally, calls to {@link View#setLayoutParams(ViewGroup.LayoutParams)} are
+ * also proxied to {@link #setLayoutParams(ViewGroup.LayoutParams)}. Optionally, calls to {@link View#getPaddingLeft()}
+ * (and others) are proxied to {@link #getUnshadowedPaddingLeft()}. Note that some of these methods are called by the
+ * {@link View}'s super constructor, so its {@link ElevationDelegate} will be null at that stage, so check for it.
+ * It does the necessary setup upon creation.
+ *
+ * Caveats:
+ * - {@link View#getPaddingLeft()} and others include the shadow padding, so if it used for calculations and re-set
+ * on the view via the proxied {@link #setPadding(int, int, int, int)} there will be double margin. To avoid this, add
+ * methods in your View and proxy them to {@link #getUnshadowedPaddingLeft()} and others.
+ * - Shadowed {@link ViewGroup.LayoutParams#MATCH_PARENT} views will be clipped by their parent. Use
+ * {@link android.R.attr#clipChildren} explicitly or, if it won't be visible, hide the side.
+ */
+public class ElevationDelegate<T extends View & ElevationDelegate.Host> {
+    private static final int SHOW_SHADOW_LEFT = 0x01;
+    private static final int SHOW_SHADOW_TOP = 0x02;
+    private static final int SHOW_SHADOW_RIGHT = 0x04;
+    private static final int SHOW_SHADOW_BOTTOM = 0x08;
+    private static final int SHOW_ALL_SHADOWS = 0xff;
+
+    private T mView;
+    private float mElevation = 0f;
+    private float mCornerRadius = 0f;
+    private boolean mShowShadowLeft = true;
+    private boolean mShowShadowTop = true;
+    private boolean mShowShadowRight = true;
+    private boolean mShowShadowBottom = true;
+
+    public ElevationDelegate(T view) {
+        this(view, null, 0);
+    }
+
+    /**
+     * Creates and returns a configured {@link ElevationDelegate}. Initial setup of the {@link View}, such as wrapping
+     * its background inside a {@link ElevationWrapperDrawable}, is done automatically.
+     */
+    public ElevationDelegate(T view, AttributeSet attrs, int defStyleAttr) {
+        mView = view;
+
+        // Parse the attrs, if any.
+        if (attrs != null) {
+            TypedArray a =
+                    view.getContext().obtainStyledAttributes(attrs, R.styleable.ElevationDelegate, defStyleAttr, 0);
+            mElevation = a.getDimensionPixelOffset(R.styleable.ElevationDelegate_elevation, 0);
+            mCornerRadius = a.getDimensionPixelOffset(R.styleable.ElevationDelegate_cornerRadius, 0);
+            int showShadows = a.getInt(R.styleable.ElevationDelegate_showShadows, SHOW_ALL_SHADOWS);
+            mShowShadowLeft = (showShadows & SHOW_SHADOW_LEFT) == SHOW_SHADOW_LEFT;
+            mShowShadowTop = (showShadows & SHOW_SHADOW_TOP) == SHOW_SHADOW_TOP;
+            mShowShadowRight = (showShadows & SHOW_SHADOW_RIGHT) == SHOW_SHADOW_RIGHT;
+            mShowShadowBottom = (showShadows & SHOW_SHADOW_BOTTOM) == SHOW_SHADOW_BOTTOM;
+            a.recycle();
+        }
+
+        // Ensure the background set on the view is a ShadowDrawableWrapper.
+        Drawable background = mView.getBackground();
+        if (background != null && !(background instanceof ElevationWrapperDrawable)) {
+            mView.setBackground(null); // Removes the callback.
+            setBackground(background);
+        }
+    }
+
+    /**
+     * @see {@link View#getElevation()}.
+     */
+    public float getElevation() {
+        return mElevation;
+    }
+
+    /**
+     * @see {@link View#setElevation(float)}.
+     */
+    public void setElevation(float elevation) {
+        mElevation = elevation;
+
+        ElevationWrapperDrawable elevationWrapperDrawable = getShadowDrawableWrapper();
+        if (elevationWrapperDrawable != null) {
+            int unshadowedPaddingLeft = getUnshadowedPaddingLeft();
+            int unshadowedPaddingTop = getUnshadowedPaddingTop();
+            int unshadowedPaddingRight = getUnshadowedPaddingRight();
+            int unshadowedPaddingBottom = getUnshadowedPaddingBottom();
+
+            elevationWrapperDrawable.setElevation(elevation);
+
+            setPadding(unshadowedPaddingLeft, unshadowedPaddingTop, unshadowedPaddingRight, unshadowedPaddingBottom);
+        }
+    }
+
+    /**
+     * Sets the corner radius for the elevation shadow.
+     * For regular backgrounds, it's 0. For circular backgrounds, it's the same as the width and height.
+     */
+    public void setCornerRadius(float cornerRadius) {
+        mCornerRadius = cornerRadius;
+
+        ElevationWrapperDrawable elevationWrapperDrawable = getShadowDrawableWrapper();
+        if (elevationWrapperDrawable != null) {
+            elevationWrapperDrawable.setCornerRadius(cornerRadius);
+        }
+    }
+
+    /**
+     * Sets the edges where the shadow will be drawn. The edges will be padded.
+     */
+    public void setShownShadows(boolean left, boolean top, boolean right, boolean bottom) {
+        mShowShadowLeft = left;
+        mShowShadowTop = top;
+        mShowShadowRight = right;
+        mShowShadowBottom = bottom;
+
+        ElevationWrapperDrawable elevationWrapperDrawable = getShadowDrawableWrapper();
+        if (elevationWrapperDrawable != null) {
+            int unshadowedPaddingLeft = getUnshadowedPaddingLeft();
+            int unshadowedPaddingTop = getUnshadowedPaddingTop();
+            int unshadowedPaddingRight = getUnshadowedPaddingRight();
+            int unshadowedPaddingBottom = getUnshadowedPaddingBottom();
+
+            elevationWrapperDrawable.setShownShadows(mShowShadowLeft, mShowShadowTop,
+                                                  mShowShadowRight, mShowShadowBottom);
+
+            setPadding(unshadowedPaddingLeft, unshadowedPaddingTop, unshadowedPaddingRight, unshadowedPaddingBottom);
+        }
+    }
+
+    /**
+     * Wraps {@code background} inside a {@link ElevationWrapperDrawable} so that a shadow is drawn around it.
+     * The3 needed padding is added automatically.
+     *
+     * Proxy {@link View#setBackground(Drawable)} calls here.
+     */
+    public void setBackground(Drawable background) {
+        int unshadowedPaddingLeft = getUnshadowedPaddingLeft();
+        int unshadowedPaddingTop = getUnshadowedPaddingTop();
+        int unshadowedPaddingRight = getUnshadowedPaddingRight();
+        int unshadowedPaddingBottom = getUnshadowedPaddingBottom();
+
+        mView.superSetBackground(new ElevationWrapperDrawable(background, mView, mElevation, mCornerRadius,
+                                                              mShowShadowLeft, mShowShadowTop,
+                                                              mShowShadowRight, mShowShadowBottom));
+
+        setPadding(unshadowedPaddingLeft, unshadowedPaddingTop, unshadowedPaddingRight, unshadowedPaddingBottom);
+    }
+
+    /**
+     * Adjusts the padding to account for the extra padding needed for the shadow and sets it in the {@link View}.
+     *
+     * Proxy {@link View#setPadding(int, int, int, int)} calls here.
+     *
+     * @see #getUnshadowedPaddingLeft()
+     * @see #getUnshadowedPaddingTop()
+     * @see #getUnshadowedPaddingRight()
+     * @see #getUnshadowedPaddingBottom()
+     */
+    public void setPadding(int left, int top, int right, int bottom) {
+        ElevationWrapperDrawable elevationWrapperDrawable = getShadowDrawableWrapper();
+        if (elevationWrapperDrawable != null) {
+            left += elevationWrapperDrawable.getPaddingLeft();
+            top += elevationWrapperDrawable.getPaddingTop();
+            right += elevationWrapperDrawable.getPaddingRight();
+            bottom += elevationWrapperDrawable.getPaddingBottom();
+        }
+        mView.superSetPadding(left, top, right, bottom);
+    }
+
+    /**
+     * Adjusts the padding to account for the extra padding needed for the shadow and sets it in the {@link View}.
+     *
+     * Proxy {@link View#setPaddingRelative(int, int, int, int)} calls here.
+     *
+     * @see #getUnshadowedPaddingStart()
+     * @see #getUnshadowedPaddingTop()
+     * @see #getUnshadowedPaddingEnd()
+     * @see #getUnshadowedPaddingBottom()
+     */
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+    public void setPaddingRelative(int start, int top, int end, int bottom) {
+        boolean rtl = mView.getLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
+        setPadding(rtl ? end : start, top, rtl ? start : end, bottom);
+    }
+
+    public void setLayoutParams(ViewGroup.LayoutParams layoutParams) {
+        ElevationWrapperDrawable elevationWrapperDrawable;
+        if (layoutParams != null && (elevationWrapperDrawable = getShadowDrawableWrapper()) != null) {
+            int paddingLeft = elevationWrapperDrawable.getPaddingLeft();
+            int paddingTop = elevationWrapperDrawable.getPaddingTop();
+            int paddingRight = elevationWrapperDrawable.getPaddingRight();
+            int paddingBottom = elevationWrapperDrawable.getPaddingBottom();
+
+            if (layoutParams.width > 0) {
+                layoutParams.width += paddingLeft + paddingRight;
+            }
+            if (layoutParams.height > 0) {
+                layoutParams.height += paddingTop + paddingBottom;
+            }
+
+            if (layoutParams instanceof ViewGroup.MarginLayoutParams) {
+                ViewGroup.MarginLayoutParams marginLayoutParams = (ViewGroup.MarginLayoutParams) layoutParams;
+                marginLayoutParams.leftMargin -= paddingLeft;
+                marginLayoutParams.topMargin -= paddingTop;
+                marginLayoutParams.rightMargin -= paddingRight;
+                marginLayoutParams.bottomMargin -= paddingBottom;
+            }
+        }
+        mView.superSetLayoutParams(layoutParams);
+    }
+
+    /**
+     * Returns the {@link View}'s left padding excluding the extra added for the shadow.
+     */
+    public int getUnshadowedPaddingLeft() {
+        int paddingLeft = mView.getPaddingLeft();
+        ElevationWrapperDrawable elevationWrapperDrawable = getShadowDrawableWrapper();
+        if (elevationWrapperDrawable != null) {
+            paddingLeft -= elevationWrapperDrawable.getPaddingLeft();
+        }
+        return paddingLeft;
+    }
+
+    /**
+     * Returns the {@link View}'s top padding excluding the extra added for the shadow.
+     */
+    public int getUnshadowedPaddingTop() {
+        int paddingTop = mView.getPaddingTop();
+        ElevationWrapperDrawable elevationWrapperDrawable = getShadowDrawableWrapper();
+        if (elevationWrapperDrawable != null) {
+            paddingTop -= elevationWrapperDrawable.getPaddingTop();
+        }
+        return paddingTop;
+    }
+
+    /**
+     * Returns the {@link View}'s right padding excluding the extra added for the shadow.
+     */
+    public int getUnshadowedPaddingRight() {
+        int paddingRight = mView.getPaddingRight();
+        ElevationWrapperDrawable elevationWrapperDrawable = getShadowDrawableWrapper();
+        if (elevationWrapperDrawable != null) {
+            paddingRight -= elevationWrapperDrawable.getPaddingRight();
+        }
+        return paddingRight;
+    }
+
+    /**
+     * Returns the {@link View}'s bottom padding excluding the extra added for the shadow.
+     */
+    public int getUnshadowedPaddingBottom() {
+        int paddingBottom = mView.getPaddingBottom();
+        ElevationWrapperDrawable elevationWrapperDrawable = getShadowDrawableWrapper();
+        if (elevationWrapperDrawable != null) {
+            paddingBottom -= elevationWrapperDrawable.getPaddingBottom();
+        }
+        return paddingBottom;
+    }
+
+    /**
+     * Returns the {@link View}'s start padding excluding the extra added for the shadow.
+     */
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+    public int getUnshadowedPaddingStart() {
+        return mView.getLayoutDirection() == View.LAYOUT_DIRECTION_RTL ? getUnshadowedPaddingRight()
+                                                                       : getUnshadowedPaddingLeft();
+    }
+
+    /**
+     * Returns the {@link View}'s end padding excluding the extra added for the shadow.
+     */
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+    public int getUnshadowedPaddingEnd() {
+        return mView.getLayoutDirection() == View.LAYOUT_DIRECTION_RTL ? getUnshadowedPaddingLeft()
+                                                                       : getUnshadowedPaddingRight();
+    }
+
+    private ElevationWrapperDrawable getShadowDrawableWrapper() {
+        Drawable background = mView.getBackground();
+        if (background instanceof ElevationWrapperDrawable) {
+            return (ElevationWrapperDrawable) background;
+        } else {
+            return null;
+        }
+    }
+
+    public interface Host {
+        /**
+         * Set the background using the {@link View}'s superclass. Used to avoid invocation loops.
+         */
+        void superSetBackground(Drawable background);
+
+        /**
+         * Set the padding using the {@link View}'s superclass. Used to avoid invocation loops.
+         */
+        void superSetPadding(int left, int top, int right, int bottom);
+
+        /**
+         * Set the layout params using the {@link View}'s superclass. Used to avoid invocation loops.
+         */
+        void superSetLayoutParams(ViewGroup.LayoutParams params);
+    }
+}

--- a/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationDelegate.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationDelegate.java
@@ -67,11 +67,11 @@ public class ElevationDelegate {
                     view.getContext().obtainStyledAttributes(attrs, R.styleable.ElevationDelegate, defStyleAttr, 0);
             mElevation = a.getDimensionPixelOffset(R.styleable.ElevationDelegate_elevation, 0);
             mCornerRadius = a.getDimensionPixelOffset(R.styleable.ElevationDelegate_cornerRadius, 0);
-            int showShadows = a.getInt(R.styleable.ElevationDelegate_showShadows, SHOW_ALL_SHADOWS);
-            mShowShadowLeft = (showShadows & SHOW_SHADOW_LEFT) == SHOW_SHADOW_LEFT;
-            mShowShadowTop = (showShadows & SHOW_SHADOW_TOP) == SHOW_SHADOW_TOP;
-            mShowShadowRight = (showShadows & SHOW_SHADOW_RIGHT) == SHOW_SHADOW_RIGHT;
-            mShowShadowBottom = (showShadows & SHOW_SHADOW_BOTTOM) == SHOW_SHADOW_BOTTOM;
+            int shownShadows = a.getInt(R.styleable.ElevationDelegate_shownShadows, SHOW_ALL_SHADOWS);
+            mShowShadowLeft = (shownShadows & SHOW_SHADOW_LEFT) == SHOW_SHADOW_LEFT;
+            mShowShadowTop = (shownShadows & SHOW_SHADOW_TOP) == SHOW_SHADOW_TOP;
+            mShowShadowRight = (shownShadows & SHOW_SHADOW_RIGHT) == SHOW_SHADOW_RIGHT;
+            mShowShadowBottom = (shownShadows & SHOW_SHADOW_BOTTOM) == SHOW_SHADOW_BOTTOM;
             a.recycle();
         }
     }

--- a/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationDelegate.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationDelegate.java
@@ -281,12 +281,14 @@ public class ElevationDelegate {
         Drawable background = mView.getBackground();
         ViewGroup.LayoutParams params = mView.getLayoutParams();
         if (background != null && !(background instanceof ElevationWrapperDrawable) && params != null) {
+            // Remove the drawable to avoid the wrapper drawable callback being removed when it's set on the view below.
+            mView.setBackground(null);
+
             ElevationWrapperDrawable elevationDrawable =
                     new ElevationWrapperDrawable(background, mView, mElevation, mCornerRadius,
                                                  mShowShadowLeft, mShowShadowTop,
                                                  mShowShadowRight, mShowShadowBottom);
             // Set elevation wrapper drawable around the background.
-            mView.setBackground(null); // Removes the callback.
             mView.setBackground(elevationDrawable);
 
             int paddingLeft = elevationDrawable.getPaddingLeft();

--- a/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationDelegate.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationDelegate.java
@@ -234,38 +234,46 @@ public class ElevationDelegate {
      */
     public ViewGroup.LayoutParams getOriginalLayoutParams() {
         ViewGroup.LayoutParams params = mView.getLayoutParams();
-        ElevationWrapperDrawable elevationDrawable = getElevationDrawableWrapper();
-        if (params != null && elevationDrawable != null) {
-            int paddingLeft = elevationDrawable.getPaddingLeft();
-            int paddingTop = elevationDrawable.getPaddingTop();
-            int paddingRight = elevationDrawable.getPaddingRight();
-            int paddingBottom = elevationDrawable.getPaddingBottom();
+        if (params != null) {
+            ElevationWrapperDrawable elevationDrawable = getElevationDrawableWrapper();
+            if (elevationDrawable != null) {
+                int paddingLeft = elevationDrawable.getPaddingLeft();
+                int paddingTop = elevationDrawable.getPaddingTop();
+                int paddingRight = elevationDrawable.getPaddingRight();
+                int paddingBottom = elevationDrawable.getPaddingBottom();
 
-            ViewGroup.LayoutParams originalParams;
-            if (params instanceof ViewGroup.MarginLayoutParams) {
-                ViewGroup.MarginLayoutParams originMarginParams =
-                        new ViewGroup.MarginLayoutParams((ViewGroup.MarginLayoutParams) params);
+                ViewGroup.LayoutParams originalParams;
+                if (params instanceof ViewGroup.MarginLayoutParams) {
+                    ViewGroup.MarginLayoutParams originMarginParams =
+                            new ViewGroup.MarginLayoutParams((ViewGroup.MarginLayoutParams) params);
 
-                originMarginParams.leftMargin -= paddingLeft;
-                originMarginParams.topMargin -= paddingTop;
-                originMarginParams.rightMargin -= paddingRight;
-                originMarginParams.bottomMargin -= paddingBottom;
+                    originMarginParams.leftMargin -= paddingLeft;
+                    originMarginParams.topMargin -= paddingTop;
+                    originMarginParams.rightMargin -= paddingRight;
+                    originMarginParams.bottomMargin -= paddingBottom;
 
-                originalParams = originMarginParams;
+                    originalParams = originMarginParams;
+                } else {
+                    originalParams = new ViewGroup.LayoutParams(params);
+                }
+
+                if (params.width > 0) {
+                    originalParams.width -= paddingLeft + paddingRight;
+                }
+                if (params.height > 0) {
+                    originalParams.height -= paddingTop + paddingBottom;
+                }
+
+                return originalParams;
             } else {
-                originalParams = new ViewGroup.LayoutParams(params);
+                if (params instanceof ViewGroup.MarginLayoutParams) {
+                    return new ViewGroup.MarginLayoutParams(params);
+                } else {
+                    return new ViewGroup.LayoutParams(params);
+                }
             }
-
-            if (params.width > 0) {
-                originalParams.width -= paddingLeft + paddingRight;
-            }
-            if (params.height > 0) {
-                originalParams.height -= paddingTop + paddingBottom;
-            }
-
-            return originalParams;
         } else {
-            return params;
+            return null;
         }
     }
 

--- a/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationUpdateRunnable.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationUpdateRunnable.java
@@ -20,9 +20,6 @@ import java.lang.ref.WeakReference;
  *
  */
 class ElevationUpdateRunnable implements Runnable {
-    private static final Bitmap.Config BITMAP_CONFIG =
-            Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT ? Bitmap.Config.ARGB_8888 : Bitmap.Config.ALPHA_8;
-
     private int mLeft;
     private int mTop;
     private int mRight;
@@ -127,7 +124,7 @@ class ElevationUpdateRunnable implements Runnable {
         if (mDirtyLeft || mDirtyTop) {
             cornerBitmapTopLeft = Bitmap.createBitmap(Math.round(mShadowLengthLeft + mCornerRadius),
                                                       Math.round(mShadowLengthTop + mCornerRadius),
-                                                      BITMAP_CONFIG);
+                                                      Bitmap.Config.ALPHA_8);
             canvas.setBitmap(cornerBitmapTopLeft);
             drawCorner(canvas, mCornerRadius + mShadowLengthLeft, mCornerRadius + mShadowLengthTop,
                        mShadowLengthLeft, mShadowLengthTop, mShadowAlphaLeft, mShadowAlphaTop, 180f);
@@ -135,7 +132,7 @@ class ElevationUpdateRunnable implements Runnable {
         if (mDirtyTop || mDirtyRight) {
             cornerBitmapTopRight = Bitmap.createBitmap(Math.round(mShadowLengthRight + mCornerRadius),
                                                        Math.round(mShadowLengthTop + mCornerRadius),
-                                                       BITMAP_CONFIG);
+                                                       Bitmap.Config.ALPHA_8);
             canvas.setBitmap(cornerBitmapTopRight);
             drawCorner(canvas, 0,  mShadowLengthTop + mCornerRadius,
                        mShadowLengthTop, mShadowLengthRight, mShadowAlphaTop, mShadowAlphaRight, -90f);
@@ -143,7 +140,7 @@ class ElevationUpdateRunnable implements Runnable {
         if (mDirtyRight || mDirtyBottom) {
             cornerBitmapBottomRight = Bitmap.createBitmap(Math.round(mShadowLengthRight + mCornerRadius),
                                                           Math.round(mShadowLengthBottom + mCornerRadius),
-                                                          BITMAP_CONFIG);
+                                                          Bitmap.Config.ALPHA_8);
             canvas.setBitmap(cornerBitmapBottomRight);
             drawCorner(canvas, 0, 0,
                        mShadowLengthRight, mShadowLengthBottom, mShadowAlphaRight, mShadowAlphaBottom, 0f);
@@ -151,7 +148,7 @@ class ElevationUpdateRunnable implements Runnable {
         if (mDirtyBottom || mDirtyLeft) {
             cornerBitmapBottomLeft = Bitmap.createBitmap(Math.round(mShadowLengthLeft + mCornerRadius),
                                                          Math.round(mShadowLengthBottom + mCornerRadius),
-                                                         BITMAP_CONFIG);
+                                                         Bitmap.Config.ALPHA_8);
             canvas.setBitmap(cornerBitmapBottomLeft);
             drawCorner(canvas, mCornerRadius + mShadowLengthLeft, 0,
                        mShadowLengthBottom, mShadowLengthLeft, mShadowAlphaBottom, mShadowAlphaLeft, 90f);

--- a/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationUpdateRunnable.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationUpdateRunnable.java
@@ -1,0 +1,241 @@
+package io.doist.material.elevation;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.LinearGradient;
+import android.graphics.Paint;
+import android.graphics.Path;
+import android.graphics.RadialGradient;
+import android.graphics.RectF;
+import android.graphics.Shader;
+import android.os.Build;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * Creates {@link Shader} for drawing the edges of the shadow and {@link Bitmap} for drawing the corners.
+ *
+ * A {@link ShadowUpdateListener} is needed to obtain the result data.
+ *
+ */
+class ElevationUpdateRunnable implements Runnable {
+    private static final Bitmap.Config BITMAP_CONFIG =
+            Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT ? Bitmap.Config.ARGB_8888 : Bitmap.Config.ALPHA_8;
+
+    private int mLeft;
+    private int mTop;
+    private int mRight;
+    private int mBottom;
+
+    private float mCornerRadius;
+
+    private int mShadowLengthLeft;
+    private int mShadowLengthTop;
+    private int mShadowLengthRight;
+    private int mShadowLengthBottom;
+
+    private float mShadowAlphaLeft;
+    private float mShadowAlphaTop;
+    private float mShadowAlphaRight;
+    private float mShadowAlphaBottom;
+
+    private boolean mDirtyLeft;
+    private boolean mDirtyTop;
+    private boolean mDirtyRight;
+    private boolean mDirtyBottom;
+
+    private WeakReference<ShadowUpdateListener> mListenerRef;
+
+    // Temporary variables reused while drawing each slice of each corner.
+    private Path mTmpCornerSlicePath;
+    private Paint mTmpCornerSlicePaint;
+    private RectF mTmpCornerSliceRectF;
+    private int[] mTmpCornerColors = new int[]{Color.TRANSPARENT, Color.TRANSPARENT, -1, Color.TRANSPARENT};
+    private float[] mTmpCornerStops = new float[]{0f, -1, -1, 1f};
+
+    public ElevationUpdateRunnable(int left, int top, int right, int bottom, float cornerRadius,
+                                   int shadowLengthLeft, int shadowLengthTop,
+                                   int shadowLengthRight, int shadowLengthBottom,
+                                   float shadowAlphaLeft, float shadowAlphaTop,
+                                   float shadowAlphaRight, float shadowAlphaBottom,
+                                   boolean dirtyLeft, boolean dirtyTop, boolean dirtyRight, boolean dirtyBottom,
+                                   ShadowUpdateListener listener) {
+        mLeft = left;
+        mTop = top;
+        mRight = right;
+        mBottom = bottom;
+        mCornerRadius = cornerRadius;
+        mShadowLengthLeft = shadowLengthLeft;
+        mShadowLengthTop = shadowLengthTop;
+        mShadowLengthRight = shadowLengthRight;
+        mShadowLengthBottom = shadowLengthBottom;
+        mShadowAlphaLeft = shadowAlphaLeft;
+        mShadowAlphaTop = shadowAlphaTop;
+        mShadowAlphaRight = shadowAlphaRight;
+        mShadowAlphaBottom = shadowAlphaBottom;
+        mDirtyLeft = dirtyLeft;
+        mDirtyTop = dirtyTop;
+        mDirtyRight = dirtyRight;
+        mDirtyBottom = dirtyBottom;
+        mListenerRef = new WeakReference<>(listener);
+
+        mTmpCornerSlicePath = new Path();
+        mTmpCornerSlicePath.setFillType(Path.FillType.EVEN_ODD);
+        mTmpCornerSlicePaint = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.DITHER_FLAG);
+        mTmpCornerSlicePaint.setStyle(Paint.Style.FILL);
+        mTmpCornerSliceRectF = new RectF();
+    }
+
+    /**
+     * Updates edge paints and corner bitmaps for the current state and given the dirty flags, and calls back the
+     * {@link ShadowUpdateListener} when done.
+     */
+    @Override
+    public void run() {
+        int width = mRight - mLeft;
+        int height = mBottom - mTop;
+
+        Shader edgeShaderLeft = null;
+        Shader edgeShaderTop = null;
+        Shader edgeShaderRight = null;
+        Shader edgeShaderBottom = null;
+        Bitmap cornerBitmapTopLeft = null;
+        Bitmap cornerBitmapTopRight = null;
+        Bitmap cornerBitmapBottomRight = null;
+        Bitmap cornerBitmapBottomLeft = null;
+
+        // Build edge gradients and set them in the edge paints.
+        if (mDirtyLeft) {
+            edgeShaderLeft = buildEdgeShader(mShadowLengthLeft, 0, 0, 0, mShadowAlphaLeft);
+        }
+        if (mDirtyTop) {
+            edgeShaderTop = buildEdgeShader(0, mShadowLengthTop, 0, 0, mShadowAlphaTop);
+        }
+        if (mDirtyRight || mDirtyLeft) {
+            edgeShaderRight = buildEdgeShader(mShadowLengthLeft + width, 0,
+                                              mShadowLengthLeft + width + mShadowLengthRight, 0, mShadowAlphaRight);
+        }
+        if (mDirtyBottom || mDirtyTop) {
+            edgeShaderBottom = buildEdgeShader(0, mShadowLengthTop + height,
+                                               0, mShadowLengthTop + height + mShadowLengthBottom, mShadowAlphaBottom);
+        }
+
+        // Build corner gradients (1 per slice) and draw them. Each corner bitmap is an alpha mask.
+        // Drawing all paths with their respective paints directly is very expensive as there can be a lot of paths.
+        Canvas canvas = new Canvas();
+        if (mDirtyLeft || mDirtyTop) {
+            cornerBitmapTopLeft = Bitmap.createBitmap(Math.round(mShadowLengthLeft + mCornerRadius),
+                                                      Math.round(mShadowLengthTop + mCornerRadius),
+                                                      BITMAP_CONFIG);
+            canvas.setBitmap(cornerBitmapTopLeft);
+            drawCorner(canvas, mCornerRadius + mShadowLengthLeft, mCornerRadius + mShadowLengthTop,
+                       mShadowLengthLeft, mShadowLengthTop, mShadowAlphaLeft, mShadowAlphaTop, 180f);
+        }
+        if (mDirtyTop || mDirtyRight) {
+            cornerBitmapTopRight = Bitmap.createBitmap(Math.round(mShadowLengthRight + mCornerRadius),
+                                                       Math.round(mShadowLengthTop + mCornerRadius),
+                                                       BITMAP_CONFIG);
+            canvas.setBitmap(cornerBitmapTopRight);
+            drawCorner(canvas, 0,  mShadowLengthTop + mCornerRadius,
+                       mShadowLengthTop, mShadowLengthRight, mShadowAlphaTop, mShadowAlphaRight, -90f);
+        }
+        if (mDirtyRight || mDirtyBottom) {
+            cornerBitmapBottomRight = Bitmap.createBitmap(Math.round(mShadowLengthRight + mCornerRadius),
+                                                          Math.round(mShadowLengthBottom + mCornerRadius),
+                                                          BITMAP_CONFIG);
+            canvas.setBitmap(cornerBitmapBottomRight);
+            drawCorner(canvas, 0, 0,
+                       mShadowLengthRight, mShadowLengthBottom, mShadowAlphaRight, mShadowAlphaBottom, 0f);
+        }
+        if (mDirtyBottom || mDirtyLeft) {
+            cornerBitmapBottomLeft = Bitmap.createBitmap(Math.round(mShadowLengthLeft + mCornerRadius),
+                                                         Math.round(mShadowLengthBottom + mCornerRadius),
+                                                         BITMAP_CONFIG);
+            canvas.setBitmap(cornerBitmapBottomLeft);
+            drawCorner(canvas, mCornerRadius + mShadowLengthLeft, 0,
+                       mShadowLengthBottom, mShadowLengthLeft, mShadowAlphaBottom, mShadowAlphaLeft, 90f);
+        }
+
+        // Propagate the update to the callback.
+        ShadowUpdateListener listener = mListenerRef.get();
+        if (listener != null) {
+            listener.onShadowUpdate(mShadowLengthLeft, mShadowLengthTop, mShadowLengthRight, mShadowLengthBottom,
+                                    mDirtyLeft, mDirtyTop, mDirtyRight, mDirtyBottom,
+                                    edgeShaderLeft, edgeShaderTop, edgeShaderRight, edgeShaderBottom,
+                                    cornerBitmapTopLeft, cornerBitmapTopRight,
+                                    cornerBitmapBottomRight, cornerBitmapBottomLeft);
+        }
+    }
+
+    /**
+     * Build a {@link LinearGradient} based on the passed-in coordinates and alpha.
+     * Used for building edge gradients.
+     */
+    private Shader buildEdgeShader(float startX, float startY, float endX, float endY, float shadowAlpha) {
+        return new LinearGradient(startX, startY, endX, endY,
+                                  Color.argb((int) (255 * shadowAlpha), 0, 0, 0), Color.TRANSPARENT,
+                                  Shader.TileMode.CLAMP);
+    }
+
+    /**
+     * Draw a corner in the given {@link Canvas} using multiple slices to accommodate for different start / end
+     * sizes. Each slice has its own {@link RadialGradient} to cross-fade between the start / end colors.
+     * Used for building corner alpha masks.
+     */
+    private void drawCorner(Canvas canvas, float centerX, float centerY,
+                            float startShadowLength, float endShadowLength,
+                            float startShadowAlpha, float endShadowAlpha,
+                            float startAngle) {
+        int shadowDiff = (int) (endShadowLength - startShadowLength);
+        int steps = Math.abs(shadowDiff) + 1;
+        float sweepAngle = 90f / steps;
+        for (int i = 0; i < steps; i++) {
+            buildCornerSlicePathPaint(
+                    centerX, centerY,
+                    startShadowLength + (shadowDiff > 0 ? i : -i), mCornerRadius,
+                    startAngle + sweepAngle * i, sweepAngle,
+                    startShadowAlpha + ((i + 1) * (endShadowAlpha - startShadowAlpha) / (steps + 1)));
+
+            canvas.drawPath(mTmpCornerSlicePath, mTmpCornerSlicePaint);
+        }
+    }
+
+    /**
+     * Build both the {@link Path} and {@link Paint} for a given slice of a corner.
+     */
+    private void buildCornerSlicePathPaint(float centerX, float centerY,
+                                           float shadowLength, float cornerRadius,
+                                           float startingAngle, float sweepAngle,
+                                           float shadowAlpha) {
+        mTmpCornerSlicePath.rewind();
+        float totalLength = shadowLength + cornerRadius;
+        mTmpCornerSliceRectF.set(-totalLength, -totalLength, totalLength, totalLength);
+        mTmpCornerSliceRectF.offset(centerX, centerY);
+        mTmpCornerSlicePath.arcTo(mTmpCornerSliceRectF, startingAngle, sweepAngle);
+        mTmpCornerSliceRectF.inset(totalLength, totalLength);
+        mTmpCornerSlicePath.lineTo(centerX, centerY);
+        mTmpCornerSlicePath.arcTo(mTmpCornerSliceRectF, startingAngle + sweepAngle, -sweepAngle);
+        mTmpCornerSlicePath.close();
+
+        mTmpCornerColors[2] = Color.argb((int) (255 * shadowAlpha), 0, 0, 0);
+        mTmpCornerStops[2] = cornerRadius / totalLength;
+        mTmpCornerStops[1] = Math.max(0f, mTmpCornerStops[2] - 1f / totalLength /* Poor man's AA. */);
+
+        mTmpCornerSlicePaint.setShader(new RadialGradient(centerX, centerY, totalLength,
+                                                          mTmpCornerColors, mTmpCornerStops,
+                                                          Shader.TileMode.CLAMP));
+    }
+
+    /**
+     * Listen for shadow updates following {@link ElevationUpdateRunnable} runs.
+     */
+    public interface ShadowUpdateListener {
+        void onShadowUpdate(int shadowLeftLength, int shadowTopLength, int shadowRightLenght, int shadowBottomLength,
+                            boolean leftDirty, boolean topDirty, boolean rightDirty, boolean bottomDirty,
+                            Shader leftEdgeShader, Shader topEdgeShader,
+                            Shader rightEdgeShader, Shader bottomEdgeShader,
+                            Bitmap topLeftCornerBitmap, Bitmap topRightCornerBitmap,
+                            Bitmap bottomRightCornerBitmap, Bitmap bottomLeftCornerBitmap);
+    }
+}

--- a/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationUpdateRunnable.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationUpdateRunnable.java
@@ -9,7 +9,6 @@ import android.graphics.Path;
 import android.graphics.RadialGradient;
 import android.graphics.RectF;
 import android.graphics.Shader;
-import android.os.Build;
 
 import java.lang.ref.WeakReference;
 
@@ -17,7 +16,6 @@ import java.lang.ref.WeakReference;
  * Creates {@link Shader} for drawing the edges of the shadow and {@link Bitmap} for drawing the corners.
  *
  * A {@link ShadowUpdateListener} is needed to obtain the result data.
- *
  */
 class ElevationUpdateRunnable implements Runnable {
     private int mLeft;
@@ -79,8 +77,9 @@ class ElevationUpdateRunnable implements Runnable {
 
         mTmpCornerSlicePath = new Path();
         mTmpCornerSlicePath.setFillType(Path.FillType.EVEN_ODD);
-        mTmpCornerSlicePaint = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.DITHER_FLAG);
+        mTmpCornerSlicePaint = new Paint();
         mTmpCornerSlicePaint.setStyle(Paint.Style.FILL);
+        mTmpCornerSlicePaint.setColor(Color.BLACK);
         mTmpCornerSliceRectF = new RectF();
     }
 
@@ -186,13 +185,15 @@ class ElevationUpdateRunnable implements Runnable {
                             float startAngle) {
         int shadowDiff = (int) (endShadowLength - startShadowLength);
         int steps = Math.abs(shadowDiff) + 1;
+
         float sweepAngle = 90f / steps;
+        float sweepShadowAlpha = (endShadowAlpha - startShadowAlpha) / (steps + 1);
         for (int i = 0; i < steps; i++) {
             buildCornerSlicePathPaint(
                     centerX, centerY,
                     startShadowLength + (shadowDiff > 0 ? i : -i), mCornerRadius,
                     startAngle + sweepAngle * i, sweepAngle,
-                    startShadowAlpha + ((i + 1) * (endShadowAlpha - startShadowAlpha) / (steps + 1)));
+                    startShadowAlpha + (i + 1) * sweepShadowAlpha);
 
             canvas.drawPath(mTmpCornerSlicePath, mTmpCornerSlicePaint);
         }

--- a/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationUpdateRunnable.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationUpdateRunnable.java
@@ -229,7 +229,7 @@ class ElevationUpdateRunnable implements Runnable {
      * Listen for shadow updates following {@link ElevationUpdateRunnable} runs.
      */
     public interface ShadowUpdateListener {
-        void onShadowUpdate(int shadowLeftLength, int shadowTopLength, int shadowRightLenght, int shadowBottomLength,
+        void onShadowUpdate(int shadowLeftLength, int shadowTopLength, int shadowRightLength, int shadowBottomLength,
                             boolean leftDirty, boolean topDirty, boolean rightDirty, boolean bottomDirty,
                             Shader leftEdgeShader, Shader topEdgeShader,
                             Shader rightEdgeShader, Shader bottomEdgeShader,

--- a/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationWrapperDrawable.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationWrapperDrawable.java
@@ -2,7 +2,6 @@ package io.doist.material.elevation;
 
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
-import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.PixelFormat;
 import android.graphics.Rect;
@@ -22,6 +21,9 @@ import java.util.concurrent.TimeUnit;
 
 import io.doist.material.drawable.WrapperDrawable;
 
+/**
+ * Wraps a {@link Drawable} and draws an elevation drop shadow around it.
+ */
 class ElevationWrapperDrawable extends WrapperDrawable implements ElevationUpdateRunnable.ShadowUpdateListener {
     // For calculating each shadow length.
     private static final int LIGHT_HEIGHT_DIP = 800;
@@ -129,8 +131,7 @@ class ElevationWrapperDrawable extends WrapperDrawable implements ElevationUpdat
         mShadowPaintTop = new Paint(mShadowPaintLeft);
         mShadowPaintRight = new Paint(mShadowPaintLeft);
         mShadowPaintBottom = new Paint(mShadowPaintLeft);
-        mCornerPaint = new Paint(mShadowPaintLeft);
-        mCornerPaint.setColor(Color.BLACK);
+        mCornerPaint = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.DITHER_FLAG);
 
         calculatePadding();
     }
@@ -280,11 +281,9 @@ class ElevationWrapperDrawable extends WrapperDrawable implements ElevationUpdat
                             mShadowPaintTop);
         }
         if (mShowShadowRight) {
-            int left = mShadowLengthLeft + width;
-            int right = mShadowLengthLeft + width + mShadowLengthRight;
-            canvas.drawRect(left,
+            canvas.drawRect(mShadowLengthLeft + width,
                             mShadowLengthTop + mCornerRadius,
-                            right,
+                            mShadowLengthLeft + width + mShadowLengthRight,
                             mShadowLengthTop + height - mCornerRadius,
                             mShadowPaintRight);
         }

--- a/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationWrapperDrawable.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationWrapperDrawable.java
@@ -2,6 +2,7 @@ package io.doist.material.elevation;
 
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
+import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.PixelFormat;
 import android.graphics.Rect;
@@ -30,8 +31,8 @@ class ElevationWrapperDrawable extends WrapperDrawable implements ElevationUpdat
     // For calculating each shadows alpha.
     private static final float AMBIENT_ALPHA = 0.09f;
     private static final float SIDE_ALPHA = 0.14f;
-    private static final float MIN_BOTTOM_ALPHA = 0.16f; // Bottom shadow when at top.
-    private static final float INC_BOTTOM_ALPHA = 0.07f; // Bottom shadow increment when at the bottom.
+    private static final float MIN_BOTTOM_ALPHA = 0.18f; // Bottom shadow when at top.
+    private static final float INC_BOTTOM_ALPHA = 0.05f; // Bottom shadow increment when at the bottom.
 
     // Executor service for calculating the shadow in the background.
     private static BlockingQueue<Runnable> sShadowExecutorQueue = new LinkedBlockingQueue<>();
@@ -129,6 +130,7 @@ class ElevationWrapperDrawable extends WrapperDrawable implements ElevationUpdat
         mShadowPaintRight = new Paint(mShadowPaintLeft);
         mShadowPaintBottom = new Paint(mShadowPaintLeft);
         mCornerPaint = new Paint(mShadowPaintLeft);
+        mCornerPaint.setColor(Color.BLACK);
 
         calculatePadding();
     }

--- a/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationWrapperDrawable.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationWrapperDrawable.java
@@ -430,7 +430,7 @@ class ElevationWrapperDrawable extends WrapperDrawable implements ElevationUpdat
      * invalidate so that they are drawn on the next cycle.
      */
     @Override
-    public void onShadowUpdate(int shadowLeftLength, int shadowTopLength, int shadowRightLenght, int shadowBottomLength,
+    public void onShadowUpdate(int shadowLeftLength, int shadowTopLength, int shadowRightLength, int shadowBottomLength,
                                boolean leftDirty, boolean topDirty, boolean rightDirty, boolean bottomDirty,
                                Shader leftEdgeShader, Shader topEdgeShader,
                                Shader rightEdgeShader, Shader bottomEdgeShader,
@@ -438,7 +438,7 @@ class ElevationWrapperDrawable extends WrapperDrawable implements ElevationUpdat
                                Bitmap bottomRightCornerBitmap, Bitmap bottomLeftCornerBitmap) {
         mShadowLengthLeft = shadowLeftLength;
         mShadowLengthTop = shadowTopLength;
-        mShadowLengthRight = shadowRightLenght;
+        mShadowLengthRight = shadowRightLength;
         mShadowLengthBottom = shadowBottomLength;
 
         if (leftDirty) {

--- a/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationWrapperDrawable.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationWrapperDrawable.java
@@ -383,7 +383,7 @@ class ElevationWrapperDrawable extends WrapperDrawable implements ElevationUpdat
      * Returns the ambient shadow for the current elevation.
      */
     private int getShadowLengthAmbient() {
-        return (int) Math.max(1, mElevation * 3 / 8);
+        return (int) Math.ceil(mElevation * 3 / 8);
     }
 
     /**

--- a/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationWrapperDrawable.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationWrapperDrawable.java
@@ -1,0 +1,487 @@
+package io.doist.material.elevation;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.PixelFormat;
+import android.graphics.Rect;
+import android.graphics.Shader;
+import android.graphics.drawable.Drawable;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.DisplayMetrics;
+import android.util.TypedValue;
+import android.view.View;
+
+import java.lang.ref.WeakReference;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import io.doist.material.drawable.WrapperDrawable;
+
+class ElevationWrapperDrawable extends WrapperDrawable implements ElevationUpdateRunnable.ShadowUpdateListener {
+    // For calculating each shadow length.
+    private static final int LIGHT_HEIGHT_DIP = 800;
+    private static final int LIGHT_Y_OFFSET_DIP = 640;
+    private static final int LIGHT_X_OFFSET_DIP = 160;
+
+    // For calculating each shadows alpha.
+    private static final float AMBIENT_ALPHA = 0.09f;
+    private static final float SIDE_ALPHA = 0.14f;
+    private static final float MIN_BOTTOM_ALPHA = 0.16f; // Bottom shadow when at top.
+    private static final float INC_BOTTOM_ALPHA = 0.07f; // Bottom shadow increment when at the bottom.
+
+    // Executor service for calculating the shadow in the background.
+    private static BlockingQueue<Runnable> sShadowExecutorQueue = new LinkedBlockingQueue<>();
+    private static ThreadPoolExecutor sShadowExecutor =
+            new ThreadPoolExecutor(0, 1, 2, TimeUnit.SECONDS, sShadowExecutorQueue);
+
+    private WeakReference<View> mViewRef;
+    private float mElevation = 0f;
+    private float mCornerRadius = 0f;
+
+    private boolean mShowShadowLeft = true;
+    private boolean mShowShadowTop = true;
+    private boolean mShowShadowRight = true;
+    private boolean mShowShadowBottom = true;
+
+    // Source light / screen.
+    private float mLightHeight;
+    private float mLightOffsetX;
+    private float mLightOffsetY;
+    private int mScreenWidth;
+    private int mScreenHeight;
+
+    // Edge paints.
+    private Paint mShadowPaintLeft;
+    private Paint mShadowPaintTop;
+    private Paint mShadowPaintRight;
+    private Paint mShadowPaintBottom;
+
+    // Corner paint.
+    private Paint mCornerPaint;
+
+    // Corner bitmaps.
+    private Bitmap mShadowBitmapTopLeft;
+    private Bitmap mShadowBitmapTopRight;
+    private Bitmap mShadowBitmapBottomRight;
+    private Bitmap mShadowBitmapBottomLeft;
+
+    // Shadow lengths in each direction.
+    private int mShadowLengthLeft;
+    private int mShadowLengthTop;
+    private int mShadowLengthRight;
+    private int mShadowLengthBottom;
+
+    // Shadow padding in each direction (maximum possible).
+    private int mShadowPaddingLeft;
+    private int mShadowPaddingTop;
+    private int mShadowPaddingRight;
+    private int mShadowPaddingBottom;
+
+    // Avoid allocations.
+    private int[] mScreenLocation = new int[2];
+    private Rect mBounds = new Rect();
+    private int mLeft;
+    private int mTop;
+    private int mRight;
+    private int mBottom;
+
+    // Shadow setup or not.
+    private volatile boolean mIsShadowSetup;
+
+    // Handler for invalidating the drawable on the UI thread.
+    private Handler mHandler = new Handler(Looper.getMainLooper());
+    private Runnable mInvalidateRunnable = new Runnable() {
+        @Override
+        public void run() {
+            invalidateSelf();
+        }
+    };
+
+    public ElevationWrapperDrawable(Drawable drawable, View view, float elevation, float cornerRadius,
+                                    boolean showShadowLeft, boolean showShadowTop,
+                                    boolean showShadowRight, boolean showShadowBottom) {
+
+        super(drawable);
+
+        mViewRef = new WeakReference<>(view);
+        mElevation = elevation;
+        mCornerRadius = cornerRadius;
+
+        mShowShadowLeft = showShadowLeft;
+        mShowShadowTop = showShadowTop;
+        mShowShadowRight = showShadowRight;
+        mShowShadowBottom = showShadowBottom;
+
+        mLightHeight = dpToPx(LIGHT_HEIGHT_DIP);
+        mLightOffsetX = dpToPx(LIGHT_X_OFFSET_DIP);
+        mLightOffsetY = dpToPx(LIGHT_Y_OFFSET_DIP);
+        DisplayMetrics metrics = view.getResources().getDisplayMetrics();
+        mScreenWidth = metrics.widthPixels;
+        mScreenHeight = metrics.heightPixels;
+
+        mShadowPaintLeft = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.DITHER_FLAG);
+        mShadowPaintLeft.setStyle(Paint.Style.FILL);
+        mShadowPaintTop = new Paint(mShadowPaintLeft);
+        mShadowPaintRight = new Paint(mShadowPaintLeft);
+        mShadowPaintBottom = new Paint(mShadowPaintLeft);
+        mCornerPaint = new Paint(mShadowPaintLeft);
+
+        calculatePadding();
+    }
+
+    @Override
+    public int getOpacity() {
+        return PixelFormat.TRANSLUCENT;
+    }
+
+    @Override
+    public void setAlpha(int alpha) {
+        super.setAlpha(alpha);
+
+        mShadowPaintLeft.setAlpha(alpha);
+        mShadowPaintTop.setAlpha(alpha);
+        mShadowPaintRight.setAlpha(alpha);
+        mShadowPaintBottom.setAlpha(alpha);
+        mCornerPaint.setAlpha(alpha);
+    }
+
+    public void setShownShadows(boolean left, boolean top, boolean right, boolean bottom) {
+        if (mShowShadowLeft != left || mShowShadowTop != top
+                || mShowShadowRight != right || mShowShadowBottom != bottom) {
+            mShowShadowLeft = left;
+            mShowShadowTop = top;
+            mShowShadowRight = right;
+            mShowShadowBottom = bottom;
+
+            // Clear bitmap references, as the necessary ones will be recreated in update().
+            mShadowBitmapTopLeft = null;
+            mShadowBitmapTopRight = null;
+            mShadowBitmapBottomRight = null;
+            mShadowBitmapBottomLeft = null;
+
+            calculatePadding();
+
+            update(true, false);
+        }
+    }
+
+    /**
+     * @see {@link ElevationDelegate#setElevation(float)}.
+     */
+    public void setElevation(float elevation) {
+        if (mElevation != elevation) {
+            mElevation = elevation;
+
+            calculatePadding();
+
+            update(true, false);
+        }
+    }
+
+    /**
+     * @see {@link ElevationDelegate#setCornerRadius(float).
+     */
+    public void setCornerRadius(float cornerRadius) {
+        if (mCornerRadius != cornerRadius) {
+            mCornerRadius = cornerRadius;
+
+            update(true, false);
+        }
+    }
+
+    // Padding is managed by ElevationDelegate, as this would clear the original padding when the background is set.
+    //@Override
+    //public boolean getPadding(Rect padding) {
+    //    super.getPadding(padding);
+    //
+    //    padding.left += getPaddingLeft() + mViewPaddingLeft;
+    //    padding.top += getPaddingTop();
+    //    padding.right += getPaddingRight();
+    //    padding.bottom += getPaddingBottom();
+    //
+    //    return true;
+    //}
+
+    private void calculatePadding() {
+        mShadowPaddingLeft = getShadowLengthLeft(0);
+        mShadowPaddingTop = getShadowLengthTop();
+        mShadowPaddingRight = getShadowLengthRight(mScreenWidth);
+        mShadowPaddingBottom = getShadowLengthBottom(mScreenHeight);
+    }
+
+    public int getPaddingLeft() {
+        return mShowShadowLeft ? mShadowPaddingLeft : 0;
+    }
+
+    public int getPaddingTop() {
+        return mShowShadowTop ? mShadowPaddingTop : 0;
+    }
+
+    public int getPaddingRight() {
+        return mShowShadowRight ? mShadowPaddingRight : 0;
+    }
+
+    public int getPaddingBottom() {
+        return mShowShadowBottom ? mShadowPaddingBottom : 0;
+    }
+
+    @Override
+    protected void onBoundsChange(Rect bounds) {
+        mBounds.set(bounds.left + getPaddingLeft(),
+                    bounds.top + getPaddingTop(),
+                    bounds.right - getPaddingRight(),
+                    bounds.bottom - getPaddingBottom());
+
+        getWrappedDrawable().setBounds(mBounds);
+    }
+
+    @Override
+    public void draw(Canvas canvas) {
+        drawShadow(canvas);
+
+        super.draw(canvas);
+    }
+
+    private void drawShadow(Canvas canvas) {
+        // Bail out immediately if there's no elevation.
+        if (mElevation == 0f) {
+            return;
+        }
+
+        // Ensure shadow is up-to-date (in the background, if previously setup).
+        update(false, mIsShadowSetup);
+
+        int width = mBounds.width();
+        int height = mBounds.height();
+
+        // Translate the canvas to the area that will be drawn.
+        int count = canvas.save();
+        canvas.translate(getPaddingLeft() - mShadowLengthLeft, getPaddingTop() - mShadowLengthTop);
+
+        // Draw edges.
+        if (mShowShadowLeft) {
+            canvas.drawRect(0,
+                            mShadowLengthTop + mCornerRadius,
+                            mShadowLengthLeft,
+                            mShadowLengthTop + height - mCornerRadius,
+                            mShadowPaintLeft);
+        }
+        if (mShowShadowTop) {
+            canvas.drawRect(mShadowLengthLeft + mCornerRadius,
+                            0,
+                            mShadowLengthLeft + width - mCornerRadius,
+                            mShadowLengthTop,
+                            mShadowPaintTop);
+        }
+        if (mShowShadowRight) {
+            int left = mShadowLengthLeft + width;
+            int right = mShadowLengthLeft + width + mShadowLengthRight;
+            canvas.drawRect(left,
+                            mShadowLengthTop + mCornerRadius,
+                            right,
+                            mShadowLengthTop + height - mCornerRadius,
+                            mShadowPaintRight);
+        }
+        if (mShowShadowBottom) {
+            canvas.drawRect(mShadowLengthLeft + mCornerRadius,
+                            mShadowLengthTop + height,
+                            mShadowLengthLeft + width - mCornerRadius,
+                            mShadowLengthTop + height + mShadowLengthBottom,
+                            mShadowPaintBottom);
+        }
+
+        // Draw corners.
+        if (mShowShadowLeft || mShowShadowTop) {
+            canvas.drawBitmap(mShadowBitmapTopLeft,
+                              0,
+                              0,
+                              mCornerPaint);
+        }
+        if (mShowShadowTop || mShowShadowRight) {
+            canvas.drawBitmap(mShadowBitmapTopRight,
+                              mShadowLengthLeft + width - mCornerRadius,
+                              0,
+                              mCornerPaint);
+        }
+        if (mShowShadowRight || mShowShadowBottom) {
+            canvas.drawBitmap(mShadowBitmapBottomRight,
+                              mShadowLengthLeft + width - mCornerRadius,
+                              mShadowLengthTop + height - mCornerRadius,
+                              mCornerPaint);
+        }
+        if (mShowShadowBottom || mShowShadowLeft) {
+            canvas.drawBitmap(mShadowBitmapBottomLeft,
+                              0,
+                              mShadowLengthTop + height - mCornerRadius,
+                              mCornerPaint);
+        }
+
+        // Restore the canvas.
+        canvas.restoreToCount(count);
+    }
+
+    /**
+     * Updates the necessary edge paints and corner bitmaps for the current state.
+     *
+     * @param force forces the update to go through, even if there's no indication that the shadow has changed.
+     * @param async runs the update in the background instead of the calling thread.
+     */
+    private void update(boolean force, boolean async) {
+        View view = mViewRef.get();
+        if (view != null) {
+            view.getLocationOnScreen(mScreenLocation);
+            int left = mScreenLocation[0] + getPaddingLeft();
+            int top = mScreenLocation[1] + getPaddingTop();
+            int right = left + mBounds.width();
+            int bottom = top + mBounds.height();
+
+            if (force || left != mLeft || top != mTop || right != mRight || bottom != mBottom) {
+                mLeft = left;
+                mTop = top;
+                mRight = right;
+                mBottom = bottom;
+
+                int shadowLengthLeft = getShadowLengthLeft(left);
+                int shadowLengthTop = getShadowLengthTop();
+                int shadowLengthRight = getShadowLengthRight(right);
+                int shadowLengthBottom = getShadowLengthBottom(bottom);
+
+                boolean leftDirty = mShowShadowLeft && (force || shadowLengthLeft != mShadowLengthLeft);
+                boolean topDirty = mShowShadowTop && (force || shadowLengthTop != mShadowLengthTop);
+                boolean rightDirty = mShowShadowRight && (force || shadowLengthRight != mShadowLengthRight);
+                boolean bottomDirty = mShowShadowBottom && (force || shadowLengthBottom != mShadowLengthBottom);
+
+                if (leftDirty || topDirty || rightDirty || bottomDirty) {
+                    float shadowAlphaLeft = shadowLengthLeft > shadowLengthRight ? SIDE_ALPHA : AMBIENT_ALPHA;
+                    float shadowAlphaTop = AMBIENT_ALPHA;
+                    float shadowAlphaRight = shadowLengthRight > shadowLengthLeft ? SIDE_ALPHA : AMBIENT_ALPHA;
+                    float shadowAlphaBottom =
+                            MIN_BOTTOM_ALPHA + INC_BOTTOM_ALPHA * shadowLengthBottom / getPaddingBottom();
+
+                    ElevationUpdateRunnable runnable =
+                            new ElevationUpdateRunnable(
+                                    mLeft, mTop, mRight, mBottom, mCornerRadius,
+                                    shadowLengthLeft, shadowLengthTop, shadowLengthRight, shadowLengthBottom,
+                                    shadowAlphaLeft, shadowAlphaTop, shadowAlphaRight, shadowAlphaBottom,
+                                    leftDirty, topDirty, rightDirty, bottomDirty, this);
+                    if (async) {
+                        sShadowExecutor.execute(runnable);
+                    } else {
+                        runnable.run();
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns the ambient shadow for the current elevation.
+     */
+    private int getShadowLengthAmbient() {
+        return (int) Math.max(1, mElevation * 3 / 8);
+    }
+
+    /**
+     * Returns the left shadow length for {@code left} position.
+     */
+    private int getShadowLengthLeft(int left) {
+        int shadowLengthAmbient = getShadowLengthAmbient();
+        if (left < mScreenWidth / 2f) {
+            return Math.max(shadowLengthAmbient,
+                            (int) (mElevation / (mLightHeight / (mLightOffsetX + (mScreenWidth - left)))));
+        } else {
+            return shadowLengthAmbient;
+        }
+    }
+
+    /**
+     * Returns the top shadow length.
+     */
+    private int getShadowLengthTop() {
+        return getShadowLengthAmbient();
+    }
+
+    /**
+     * Returns the right shadow length for {@code right} position.
+     */
+    private int getShadowLengthRight(int right) {
+        int shadowLengthAmbient = getShadowLengthAmbient();
+        if (right > mScreenWidth / 2f) {
+            return Math.max(shadowLengthAmbient, (int) (mElevation / (mLightHeight / (mLightOffsetX + right))));
+        } else {
+            return shadowLengthAmbient;
+        }
+    }
+
+    /**
+     * Returns the bottom shadow length for {@code bottom} position.
+     */
+    private int getShadowLengthBottom(int bottom) {
+        return Math.max(getShadowLengthAmbient(), (int) (mElevation / (mLightHeight / (mLightOffsetY + bottom))));
+    }
+
+    /**
+     * Store the shadow calculation result ({@link Shader}s for each side, {@link Bitmap} for the corners) and
+     * invalidate so that they are drawn on the next cycle.
+     */
+    @Override
+    public void onShadowUpdate(int shadowLeftLength, int shadowTopLength, int shadowRightLenght, int shadowBottomLength,
+                               boolean leftDirty, boolean topDirty, boolean rightDirty, boolean bottomDirty,
+                               Shader leftEdgeShader, Shader topEdgeShader,
+                               Shader rightEdgeShader, Shader bottomEdgeShader,
+                               Bitmap topLeftCornerBitmap, Bitmap topRightCornerBitmap,
+                               Bitmap bottomRightCornerBitmap, Bitmap bottomLeftCornerBitmap) {
+        mShadowLengthLeft = shadowLeftLength;
+        mShadowLengthTop = shadowTopLength;
+        mShadowLengthRight = shadowRightLenght;
+        mShadowLengthBottom = shadowBottomLength;
+
+        if (leftDirty) {
+            mShadowPaintLeft.setShader(leftEdgeShader);
+        }
+        if (topDirty) {
+            mShadowPaintTop.setShader(topEdgeShader);
+        }
+        if (rightDirty || leftDirty) {
+            mShadowPaintRight.setShader(rightEdgeShader);
+        }
+        if (bottomDirty || topDirty) {
+            mShadowPaintBottom.setShader(bottomEdgeShader);
+        }
+
+        if (leftDirty || topDirty) {
+            mShadowBitmapTopLeft = topLeftCornerBitmap;
+        }
+        if (topDirty || rightDirty) {
+            mShadowBitmapTopRight = topRightCornerBitmap;
+        }
+        if (rightDirty || bottomDirty) {
+            mShadowBitmapBottomRight = bottomRightCornerBitmap;
+        }
+        if (bottomDirty || leftDirty) {
+            mShadowBitmapBottomLeft = bottomLeftCornerBitmap;
+        }
+
+        mIsShadowSetup = true;
+
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            mInvalidateRunnable.run();
+        } else {
+            mHandler.post(mInvalidateRunnable);
+        }
+    }
+
+    private float dpToPx(float dp) {
+        View view = mViewRef.get();
+        if (view != null) {
+            DisplayMetrics metrics = view.getResources().getDisplayMetrics();
+            return (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, dp, metrics);
+        } else {
+            return 0;
+        }
+    }
+}

--- a/MaterialLibrary/src/main/java/io/doist/material/widget/FloatingActionButton.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/widget/FloatingActionButton.java
@@ -21,9 +21,7 @@ import io.doist.material.elevation.ElevationDelegate;
 import io.doist.material.widget.utils.MaterialWidgetHandler;
 
 public class FloatingActionButton extends ImageButton {
-    public static final String LOG_TAG = FloatingActionButton.class.getSimpleName();
-
-    private static final int DEFAULT_ELEVATION_DP = 8;
+    private static final int DEFAULT_ELEVATION_DP = 6;
 
     private ColorStateList mColor;
 

--- a/MaterialLibrary/src/main/java/io/doist/material/widget/FloatingActionButton.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/widget/FloatingActionButton.java
@@ -38,7 +38,7 @@ public class FloatingActionButton extends ImageButton {
     }
 
     public FloatingActionButton(Context context, AttributeSet attrs) {
-        this(context, attrs, android.R.attr.imageButtonStyle);
+        this(context, attrs, 0);
     }
 
     public FloatingActionButton(Context context, AttributeSet attrs, int defStyleAttr) {

--- a/MaterialLibrary/src/main/java/io/doist/material/widget/FloatingActionButton.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/widget/FloatingActionButton.java
@@ -25,7 +25,7 @@ public class FloatingActionButton extends ImageButton implements ElevationDelega
     private ColorStateList mColor;
 
     private boolean mIsMini;
-    private int mRadius;
+    private int mSize;
 
     private GradientDrawable mCircleDrawable; // To change the color of the circle.
     private TintDrawable mTintDrawable; // To change the color of the circle in compat mode.
@@ -179,16 +179,17 @@ public class FloatingActionButton extends ImageButton implements ElevationDelega
 
     private void internalSetIsMini(boolean isMini) {
         mIsMini = isMini;
-        mRadius = getResources().getDimensionPixelOffset(isMini ? R.dimen.fab_mini_radius : R.dimen.fab_radius);
+        int radius = getResources().getDimensionPixelOffset(isMini ? R.dimen.fab_mini_radius : R.dimen.fab_radius);
+        mSize = radius * 2;
 
         if (mElevationDelegate != null) {
-            mElevationDelegate.setCornerRadius(mRadius);
+            mElevationDelegate.setCornerRadius(radius);
         }
 
         // Re-set layout params so that width and height are adjusted accordingly.
         ViewGroup.LayoutParams params = getLayoutParams();
         if (params != null) {
-            setLayoutParams(params);
+            internalSetLayoutParams(params);
         }
     }
 
@@ -216,14 +217,18 @@ public class FloatingActionButton extends ImageButton implements ElevationDelega
 
     @Override
     public void setLayoutParams(ViewGroup.LayoutParams params) {
-        if (params.width != ViewGroup.LayoutParams.WRAP_CONTENT
-                || params.height != ViewGroup.LayoutParams.WRAP_CONTENT) {
+        if ((params.width != mSize && params.width != ViewGroup.LayoutParams.WRAP_CONTENT)
+                || (params.height != mSize && params.height != ViewGroup.LayoutParams.WRAP_CONTENT)) {
             throw new IllegalStateException("FloatingActionButton 'android:width' and 'android:height' values must be "
                                                     + "'wrap_content'. Check 'isMini' attribute to manipulate size.");
         }
+        internalSetLayoutParams(params);
+    }
 
-        params.width = mRadius * 2;
-        params.height = mRadius * 2;
+
+    private void internalSetLayoutParams(ViewGroup.LayoutParams params) {
+        params.width = mSize;
+        params.height = mSize;
 
         if (mElevationDelegate != null) {
             mElevationDelegate.setLayoutParams(params);

--- a/MaterialLibrary/src/main/java/io/doist/material/widget/FloatingActionButton.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/widget/FloatingActionButton.java
@@ -1,43 +1,26 @@
 package io.doist.material.widget;
 
 import android.annotation.SuppressLint;
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.ColorStateList;
 import android.content.res.TypedArray;
-import android.graphics.Canvas;
-import android.graphics.Color;
-import android.graphics.Paint;
-import android.graphics.Point;
-import android.graphics.RadialGradient;
-import android.graphics.Shader;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
-import android.graphics.drawable.InsetDrawable;
 import android.graphics.drawable.RippleDrawable;
 import android.os.Build;
-import android.support.annotation.NonNull;
 import android.util.AttributeSet;
-import android.util.DisplayMetrics;
-import android.util.TypedValue;
-import android.view.Display;
-import android.view.View;
 import android.view.ViewGroup;
-import android.view.ViewTreeObserver;
-import android.view.WindowManager;
 import android.widget.ImageButton;
 
 import io.doist.material.R;
 import io.doist.material.color.ColorPalette;
 import io.doist.material.drawable.RippleMaterialDrawable;
 import io.doist.material.drawable.TintDrawable;
+import io.doist.material.elevation.ElevationDelegate;
 import io.doist.material.widget.utils.MaterialWidgetHandler;
 
-public class FloatingActionButton extends ImageButton {
+public class FloatingActionButton extends ImageButton implements ElevationDelegate.Host {
     private static final int DEFAULT_ELEVATION_DP = 8;
-
-    // Used to create a shadow to fake elevation in pre-L androids.
-    private ElevationManager mElevationManager;
 
     private ColorStateList mColor;
 
@@ -46,6 +29,8 @@ public class FloatingActionButton extends ImageButton {
 
     private GradientDrawable mCircleDrawable; // To change the color of the circle.
     private TintDrawable mTintDrawable; // To change the color of the circle in compat mode.
+
+    private ElevationDelegate<FloatingActionButton> mElevationDelegate;
 
     public FloatingActionButton(Context context) {
         this(context, null);
@@ -62,22 +47,19 @@ public class FloatingActionButton extends ImageButton {
 
     @SuppressWarnings("ConstantConditions")
     private void init(Context context, AttributeSet attrs, int defStyleAttr) {
-        DisplayMetrics metrics = getResources().getDisplayMetrics();
-
-        // Parse attributes.
-        // Default attr values.
         boolean inCompat = Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP;
-        int elevation = (int) (DEFAULT_ELEVATION_DP * metrics.density + .5f);
-        int padding = context.getResources().getDimensionPixelSize(R.dimen.fab_padding);
-        int paddingLeft, paddingTop, paddingRight, paddingBottom;
-        paddingLeft = paddingTop = paddingRight = paddingBottom = padding;
+        int elevation = (int) (DEFAULT_ELEVATION_DP * context.getResources().getDisplayMetrics().density + .5f);
         ColorStateList color = null;
         boolean isMini = false;
 
         if (attrs != null) {
             TypedArray ta = context.obtainStyledAttributes(attrs, R.styleable.FloatingActionButton, defStyleAttr, 0);
             try {
-                // Resolve if in compatibility mode.
+                if (ta.getDrawable(R.styleable.FloatingActionButton_android_background) != null) {
+                    throw new IllegalStateException(
+                            "FloatingActionButton does not support 'android:background' attribute.");
+                }
+
                 inCompat |= ta.getBoolean(R.styleable.FloatingActionButton_inCompat, inCompat);
 
                 if (inCompat) {
@@ -90,23 +72,8 @@ public class FloatingActionButton extends ImageButton {
                             elevation);
                 }
 
-                padding = ta.getDimensionPixelSize(R.styleable.FloatingActionButton_android_padding, padding);
-                paddingLeft = ta.getDimensionPixelSize(R.styleable.FloatingActionButton_android_paddingLeft, padding);
-                paddingTop = ta.getDimensionPixelSize(R.styleable.FloatingActionButton_android_paddingTop, padding);
-                paddingRight = ta.getDimensionPixelSize(R.styleable.FloatingActionButton_android_paddingRight, padding);
-                paddingBottom =
-                        ta.getDimensionPixelSize(R.styleable.FloatingActionButton_android_paddingBottom, padding);
-
                 // Resolve color or colorStateList.
-                TypedValue v = new TypedValue();
-                if (ta.getValue(R.styleable.FloatingActionButton_android_color, v)) {
-                    if (v.type >= TypedValue.TYPE_FIRST_COLOR_INT
-                            && v.type <= TypedValue.TYPE_LAST_COLOR_INT) {
-                        color = ColorStateList.valueOf(v.data);
-                    } else {
-                        color = ta.getColorStateList(R.styleable.FloatingActionButton_android_color);
-                    }
-                }
+                color = ta.getColorStateList(R.styleable.FloatingActionButton_android_color);
 
                 // Resolve size.
                 isMini = ta.getBoolean(R.styleable.FloatingActionButton_isMini, isMini);
@@ -116,8 +83,6 @@ public class FloatingActionButton extends ImageButton {
         }
 
         initElevation(inCompat, elevation);
-
-        setPadding(paddingLeft, paddingTop, paddingRight, paddingBottom);
 
         initDrawables(context, inCompat);
 
@@ -131,22 +96,15 @@ public class FloatingActionButton extends ImageButton {
 
     private void initElevation(boolean inCompat, float elevation) {
         if (inCompat) {
-            mElevationManager = new ElevationManager(this);
+            mElevationDelegate = new ElevationDelegate<>(this);
         }
         setElevation(elevation);
     }
 
-    @SuppressWarnings("deprecation")
     @SuppressLint("NewApi")
     private void initDrawables(Context context, boolean inCompat) {
         // TODO: Make this theme dependent.
-        ColorStateList rippleColor =
-                ColorStateList.valueOf(context.getResources().getColor(R.color.ripple_material_light));
-
-        int paddingLeft = getPaddingLeft();
-        int paddingTop = getPaddingTop();
-        int paddingRight = getPaddingRight();
-        int paddingBottom = getPaddingBottom();
+        ColorStateList rippleColor = ColorStateList.valueOf(getResources().getColor(R.color.ripple_material_light));
 
         GradientDrawable circleDrawable = new GradientDrawable();
         circleDrawable.setShape(GradientDrawable.OVAL);
@@ -155,41 +113,15 @@ public class FloatingActionButton extends ImageButton {
         if (inCompat) {
             // Pre-L androids or force compat mode.
             mTintDrawable = new TintDrawable(context, circleDrawable);
-            RippleMaterialDrawable rippleDrawable = new RippleMaterialDrawable(
-                    context,
-                    rippleColor,
-                    mTintDrawable,
-                    null);
-            rippleDrawable.setLayerInset(0, paddingLeft, paddingTop, paddingRight, paddingBottom);
-            rippleDrawable.setLayerInset(1, paddingLeft, paddingTop, paddingRight, paddingBottom);
-            background = rippleDrawable;
+            background = new RippleMaterialDrawable(context, rippleColor, mTintDrawable, null);
         } else {
             // Lollipop androids.
             mCircleDrawable = circleDrawable;
-            background = new RippleDrawable(
-                    rippleColor,
-                    new InsetDrawable(
-                            circleDrawable,
-                            paddingLeft,
-                            paddingTop,
-                            paddingRight,
-                            paddingBottom),
-                    null);
+            background = new RippleDrawable(rippleColor, circleDrawable, null);
         }
 
-        if (getBackground() != null) {
-            setBackground(background);
-
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-                // Make sure the current padding is kept in pre-L androids.
-                // Otherwise, the background drawable would override the current padding.
-                setPadding(paddingLeft, paddingTop, paddingRight, paddingBottom);
-            }
-        } else {
-            throw new IllegalStateException("FloatingActionButton does not support 'android:background' attribute.");
-        }
+        setBackground(background);
     }
-
 
     private void initColor(Context context, ColorStateList color) {
         if (color != null) {
@@ -200,21 +132,19 @@ public class FloatingActionButton extends ImageButton {
         }
     }
 
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     @Override
     public void setElevation(float elevation) {
-        if (mElevationManager != null) {
-            mElevationManager.setElevation(elevation);
+        if (mElevationDelegate != null) {
+            mElevationDelegate.setElevation(elevation);
         } else {
             super.setElevation(elevation);
         }
     }
 
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     @Override
     public float getElevation() {
-        if (mElevationManager != null) {
-            return mElevationManager.getElevation();
+        if (mElevationDelegate != null) {
+            return mElevationDelegate.getElevation();
         } else {
             return super.getElevation();
         }
@@ -244,19 +174,21 @@ public class FloatingActionButton extends ImageButton {
     public void setIsMini(boolean isMini) {
         if (mIsMini != isMini) {
             internalSetIsMini(isMini);
-            requestLayout();
-            invalidate();
         }
     }
 
-    @SuppressLint("NewApi")
     private void internalSetIsMini(boolean isMini) {
         mIsMini = isMini;
-        int radiusResId = isMini ? R.dimen.fab_mini_radius : R.dimen.fab_radius;
-        mRadius = getContext().getResources().getDimensionPixelOffset(radiusResId);
+        mRadius = getResources().getDimensionPixelOffset(isMini ? R.dimen.fab_mini_radius : R.dimen.fab_radius);
 
-        if (mElevationManager != null) {
-            mElevationManager.setRadius(mRadius);
+        if (mElevationDelegate != null) {
+            mElevationDelegate.setCornerRadius(mRadius);
+        }
+
+        // Re-set layout params so that width and height are adjusted accordingly.
+        ViewGroup.LayoutParams params = getLayoutParams();
+        if (params != null) {
+            setLayoutParams(params);
         }
     }
 
@@ -265,167 +197,53 @@ public class FloatingActionButton extends ImageButton {
     }
 
     @Override
-    public void setPadding(int left, int top, int right, int bottom) {
-        super.setPadding(left, top, right, bottom);
-
-        if (mElevationManager != null) {
-            mElevationManager.setPadding(left, top);
+    public void setBackground(Drawable background) {
+        if (mElevationDelegate != null) {
+            mElevationDelegate.setBackground(background);
+        } else {
+            super.setBackground(background);
         }
     }
 
     @Override
-    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-        setMeasuredDimension(
-                mRadius * 2 + getPaddingLeft() + getPaddingRight(),
-                mRadius * 2 + getPaddingTop() + getPaddingBottom());
+    public void setPadding(int left, int top, int right, int bottom) {
+        if (mElevationDelegate != null) {
+            mElevationDelegate.setPadding(left, top, right, bottom);
+        } else {
+            super.setPadding(left, top, right, bottom);
+        }
     }
 
     @Override
     public void setLayoutParams(ViewGroup.LayoutParams params) {
-        super.setLayoutParams(params);
         if (params.width != ViewGroup.LayoutParams.WRAP_CONTENT
                 || params.height != ViewGroup.LayoutParams.WRAP_CONTENT) {
             throw new IllegalStateException("FloatingActionButton 'android:width' and 'android:height' values must be "
                                                     + "'wrap_content'. Check 'isMini' attribute to manipulate size.");
         }
+
+        params.width = mRadius * 2;
+        params.height = mRadius * 2;
+
+        if (mElevationDelegate != null) {
+            mElevationDelegate.setLayoutParams(params);
+        } else {
+            super.setLayoutParams(params);
+        }
     }
 
     @Override
-    public void draw(@NonNull Canvas canvas) {
-        if (mElevationManager != null) {
-            mElevationManager.drawShadow(canvas);
-        }
-        super.draw(canvas);
+    public void superSetBackground(Drawable background) {
+        super.setBackground(background);
     }
 
-    private static class ElevationManager {
-        private static final float SHADOW_MULTIPLIER = 1.5f;
+    @Override
+    public void superSetPadding(int left, int top, int right, int bottom) {
+        super.setPadding(left, top, right, bottom);
+    }
 
-        // Manually tested to better replicate the elevation result.
-        private static final int SHADOW_START_COLOR = Color.argb(125, 0, 0, 0);
-        private static final int SHADOW_FIRST_STEP_COLOR = Color.argb(25, 0, 0, 0);
-        private static final int SHADOW_SECOND_STEP_COLOR = Color.argb(10, 0, 0, 0);
-        private static final int SHADOW_END_COLOR = Color.TRANSPARENT;
-
-        private static final float MAX_LOCATION_SCALE = 0.3f;
-        private static final float SHADOW_TOP_SCALE = 0.25f;
-        private static final float SHADOW_BOTTOM_SCALE = 1f;
-
-        private View mView;
-        private Paint mShadowPaint;
-        private float mScreenHeight;
-
-        private float mLocationScale;
-
-        private float mElevation;
-        private int mRadius;
-        private int mPaddingLeft;
-        private int mPaddingTop;
-
-        private boolean mInvalidate;
-        private float mShadowCx;
-        private float mShadowCy;
-        private float mShadowRadius;
-
-        public ElevationManager(View view) {
-            mView = view;
-            mShadowPaint = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.DITHER_FLAG);
-
-            WindowManager wm = (WindowManager) mView.getContext().getSystemService(Context.WINDOW_SERVICE);
-            Display display = wm.getDefaultDisplay();
-            Point size = new Point();
-            display.getSize(size);
-            mScreenHeight = size.y;
-
-            onViewLocationUpdate();
-
-            if (mView.isLayoutRequested()) {
-                mView.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
-                    @Override
-                    public void onGlobalLayout() {
-                        mView.getViewTreeObserver().removeOnGlobalLayoutListener(this);
-
-                        onViewLocationUpdate();
-                    }
-                });
-            }
-        }
-
-        public void onViewLocationUpdate() {
-            // The location on screen has influence on the shadow vertical size.
-            int[] location = new int[2];
-            mView.getLocationOnScreen(location);
-
-            float locationRatio = location[1] / mScreenHeight;
-            float locationOrigin = 0.5f;
-            mLocationScale = (-(locationOrigin - locationRatio) / (1f - locationOrigin)) * MAX_LOCATION_SCALE;
-
-            mInvalidate = true;
-        }
-
-        public void setElevation(float elevation) {
-            if (mElevation != elevation) {
-                mElevation = elevation;
-                mInvalidate = true;
-                // Force view to redraw the shadow.
-                mView.invalidate();
-                mView.requestLayout();
-            }
-        }
-
-        public float getElevation() {
-            return mElevation;
-        }
-
-        public void setRadius(int radius) {
-            if (mRadius != radius) {
-                mRadius = radius;
-                mInvalidate = true;
-            }
-        }
-
-        public void setPadding(int left, int top) {
-            if (mPaddingLeft != left || mPaddingTop != top) {
-                mPaddingLeft = left;
-                mPaddingTop = top;
-                mInvalidate = true;
-            }
-        }
-
-        private void calculateShadow() {
-            float shadowSizeBenchmark = mElevation * SHADOW_MULTIPLIER;
-            float shadowTopSize = shadowSizeBenchmark * SHADOW_TOP_SCALE;
-            float shadowBottomSize = shadowSizeBenchmark * SHADOW_BOTTOM_SCALE;
-            float shadowLocationSize = shadowSizeBenchmark * mLocationScale;
-            float shadowSize = shadowTopSize + shadowBottomSize + shadowLocationSize;
-            mShadowRadius = mRadius + (shadowSize / 2f);
-
-            mShadowCx = mRadius + mPaddingLeft;
-            float shadowCyCentered = mRadius + mPaddingTop;
-            // The shadow is on the down side of the button.
-            float shadowDy = (shadowSize / 2f) - shadowTopSize;
-            mShadowCy = shadowCyCentered + shadowDy;
-
-            float firstStep = mRadius / mShadowRadius;
-            float secondStep = firstStep + ((1f - firstStep) / 2f);
-
-            mShadowPaint.setShader(new RadialGradient(
-                    mShadowCx,
-                    mShadowCy,
-                    mShadowRadius,
-                    new int[]{SHADOW_START_COLOR, SHADOW_FIRST_STEP_COLOR, SHADOW_SECOND_STEP_COLOR, SHADOW_END_COLOR},
-                    new float[]{0f, firstStep, secondStep, 1f},
-                    Shader.TileMode.CLAMP));
-        }
-
-        public void drawShadow(Canvas canvas) {
-            if (mElevation > 0) {
-                if (mInvalidate) {
-                    mInvalidate = false;
-                    calculateShadow();
-                }
-                canvas.drawCircle(mShadowCx, mShadowCy, mShadowRadius, mShadowPaint);
-            }
-        }
+    @Override
+    public void superSetLayoutParams(ViewGroup.LayoutParams params) {
+        super.setLayoutParams(params);
     }
 }

--- a/MaterialLibrary/src/main/java/io/doist/material/widget/FloatingActionButton.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/widget/FloatingActionButton.java
@@ -34,7 +34,7 @@ import io.doist.material.drawable.TintDrawable;
 import io.doist.material.widget.utils.MaterialWidgetHandler;
 
 public class FloatingActionButton extends ImageButton {
-    private static final int DEFAULT_ELEVATION_DP = 6;
+    private static final int DEFAULT_ELEVATION_DP = 8;
 
     // Used to create a shadow to fake elevation in pre-L androids.
     private ElevationManager mElevationManager;

--- a/MaterialLibrary/src/main/res/values/attrs_elevation_delegate.xml
+++ b/MaterialLibrary/src/main/res/values/attrs_elevation_delegate.xml
@@ -3,7 +3,7 @@
     <declare-styleable name="ElevationDelegate">
         <attr name="elevation" />
         <attr name="cornerRadius" format="dimension" />
-        <attr name="showShadows">
+        <attr name="shownShadows">
             <flag name="none" value="0x00" />
             <flag name="left" value="0x01" />
             <flag name="top" value="0x02" />

--- a/MaterialLibrary/src/main/res/values/attrs_elevation_delegate.xml
+++ b/MaterialLibrary/src/main/res/values/attrs_elevation_delegate.xml
@@ -5,10 +5,10 @@
         <attr name="cornerRadius" format="dimension" />
         <attr name="showShadows">
             <flag name="none" value="0x00" />
-            <flag name="top" value="0x01" />
-            <flag name="bottom" value="0x02" />
-            <flag name="left" value="0x04" />
-            <flag name="right" value="0x08" />
+            <flag name="left" value="0x01" />
+            <flag name="top" value="0x02" />
+            <flag name="right" value="0x04" />
+            <flag name="bottom" value="0x08" />
             <flag name="all" value="0xff" />
         </attr>
     </declare-styleable>

--- a/MaterialLibrary/src/main/res/values/attrs_elevation_delegate.xml
+++ b/MaterialLibrary/src/main/res/values/attrs_elevation_delegate.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="ElevationDelegate">
+        <attr name="elevation" />
+        <attr name="cornerRadius" format="dimension" />
+        <attr name="showShadows">
+            <flag name="none" value="0x00" />
+            <flag name="top" value="0x01" />
+            <flag name="bottom" value="0x02" />
+            <flag name="left" value="0x04" />
+            <flag name="right" value="0x08" />
+            <flag name="all" value="0xff" />
+        </attr>
+    </declare-styleable>
+</resources>

--- a/MaterialLibrary/src/main/res/values/attrs_fab.xml
+++ b/MaterialLibrary/src/main/res/values/attrs_fab.xml
@@ -1,13 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <declare-styleable name="FloatingActionButton">
-        <attr name="android:src" />
+        <attr name="android:background" />
         <attr name="android:elevation" />
-        <attr name="android:padding" />
-        <attr name="android:paddingLeft" />
-        <attr name="android:paddingTop" />
-        <attr name="android:paddingRight" />
-        <attr name="android:paddingBottom" />
         <attr name="android:color" />
         <attr name="elevation" />
         <attr name="isMini" format="boolean" />

--- a/MaterialLibrary/src/main/res/values/attrs_fab.xml
+++ b/MaterialLibrary/src/main/res/values/attrs_fab.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <declare-styleable name="FloatingActionButton">
+        <attr name="android:layout_width" />
+        <attr name="android:layout_height" />
         <attr name="android:background" />
         <attr name="android:elevation" />
         <attr name="android:color" />

--- a/MaterialLibrary/src/main/res/values/dimens_fab.xml
+++ b/MaterialLibrary/src/main/res/values/dimens_fab.xml
@@ -3,9 +3,10 @@
 
     <dimen name="fab_radius">28dip</dimen>
     <dimen name="fab_mini_radius">20dip</dimen>
-    <dimen name="fab_padding">16dip</dimen>
 
-    <dimen name="fab_size">88dip</dimen>
-    <dimen name="fab_mini_size">72dip</dimen>
+    <dimen name="fab_default_margin">16dip</dimen>
+
+    <dimen name="fab_size">56dip</dimen>
+    <dimen name="fab_mini_size">40dip</dimen>
 
 </resources>

--- a/MaterialSamples/src/main/java/io/doist/material/sample/ElevatedTextView.java
+++ b/MaterialSamples/src/main/java/io/doist/material/sample/ElevatedTextView.java
@@ -1,15 +1,13 @@
 package io.doist.material.sample;
 
 import android.content.Context;
-import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
-import android.view.ViewGroup;
 import android.widget.TextView;
 
 import io.doist.material.elevation.ElevationDelegate;
 
-public class ElevatedTextView extends TextView implements ElevationDelegate.Host {
-    private ElevationDelegate<ElevatedTextView> mElevationDelegate;
+public class ElevatedTextView extends TextView {
+    private ElevationDelegate mElevationDelegate;
 
     public ElevatedTextView(Context context) {
         super(context);
@@ -27,111 +25,20 @@ public class ElevatedTextView extends TextView implements ElevationDelegate.Host
     }
 
     private void init(AttributeSet attrs, int defStyleAttr) {
-        mElevationDelegate = new ElevationDelegate<>(this, attrs, defStyleAttr);
+        mElevationDelegate = new ElevationDelegate(this, attrs, defStyleAttr);
     }
 
     @Override
-    public void setBackground(Drawable background) {
-        if (mElevationDelegate != null) {
-            mElevationDelegate.setBackground(background);
-        } else {
-            super.setBackground(background);
-        }
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+
+        mElevationDelegate.onAttachedToWindow();
     }
 
     @Override
-    public void setPadding(int left, int top, int right, int bottom) {
-        if (mElevationDelegate != null) {
-            mElevationDelegate.setPadding(left, top, right, bottom);
-        } else {
-            super.setPadding(left, top, right, bottom);
-        }
-    }
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
 
-    @Override
-    public void setPaddingRelative(int start, int top, int end, int bottom) {
-        if (mElevationDelegate != null) {
-            mElevationDelegate.setPaddingRelative(start, top, end, bottom);
-        } else {
-            super.setPaddingRelative(start, top, end, bottom);
-        }
-    }
-
-    @Override
-    public void superSetBackground(Drawable background) {
-        super.setBackground(background);
-    }
-
-    @Override
-    public void superSetPadding(int left, int top, int right, int bottom) {
-        super.setPadding(left, top, right, bottom);
-    }
-
-    @Override
-    public void setLayoutParams(ViewGroup.LayoutParams params) {
-        if (mElevationDelegate != null) {
-            mElevationDelegate.setLayoutParams(params);
-        } else {
-            super.setLayoutParams(params);
-        }
-    }
-
-    @Override
-    public void superSetLayoutParams(ViewGroup.LayoutParams params) {
-        super.setLayoutParams(params);
-    }
-
-    @Override
-    public int getPaddingLeft() {
-        if (mElevationDelegate != null) {
-            return mElevationDelegate.getUnshadowedPaddingLeft();
-        } else {
-            return super.getPaddingLeft();
-        }
-    }
-
-    @Override
-    public int getPaddingTop() {
-        if (mElevationDelegate != null) {
-            return mElevationDelegate.getUnshadowedPaddingTop();
-        } else {
-            return super.getPaddingTop();
-        }
-    }
-
-    @Override
-    public int getPaddingRight() {
-        if (mElevationDelegate != null) {
-            return mElevationDelegate.getUnshadowedPaddingRight();
-        } else {
-            return super.getPaddingRight();
-        }
-    }
-
-    @Override
-    public int getPaddingBottom() {
-        if (mElevationDelegate != null) {
-            return mElevationDelegate.getUnshadowedPaddingBottom();
-        } else {
-            return super.getPaddingBottom();
-        }
-    }
-
-    @Override
-    public int getPaddingStart() {
-        if (mElevationDelegate != null) {
-            return mElevationDelegate.getUnshadowedPaddingStart();
-        } else {
-            return super.getPaddingStart();
-        }
-    }
-
-    @Override
-    public int getPaddingEnd() {
-        if (mElevationDelegate != null) {
-            return mElevationDelegate.getUnshadowedPaddingEnd();
-        } else {
-            return super.getPaddingEnd();
-        }
+        mElevationDelegate.onDetachedFromWindow();
     }
 }

--- a/MaterialSamples/src/main/java/io/doist/material/sample/ElevatedTextView.java
+++ b/MaterialSamples/src/main/java/io/doist/material/sample/ElevatedTextView.java
@@ -1,0 +1,137 @@
+package io.doist.material.sample;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.util.AttributeSet;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import io.doist.material.elevation.ElevationDelegate;
+
+public class ElevatedTextView extends TextView implements ElevationDelegate.Host {
+    private ElevationDelegate<ElevatedTextView> mElevationDelegate;
+
+    public ElevatedTextView(Context context) {
+        super(context);
+        init(null, 0);
+    }
+
+    public ElevatedTextView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init(attrs, 0);
+    }
+
+    public ElevatedTextView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init(attrs, defStyleAttr);
+    }
+
+    private void init(AttributeSet attrs, int defStyleAttr) {
+        mElevationDelegate = new ElevationDelegate<>(this, attrs, defStyleAttr);
+    }
+
+    @Override
+    public void setBackground(Drawable background) {
+        if (mElevationDelegate != null) {
+            mElevationDelegate.setBackground(background);
+        } else {
+            super.setBackground(background);
+        }
+    }
+
+    @Override
+    public void setPadding(int left, int top, int right, int bottom) {
+        if (mElevationDelegate != null) {
+            mElevationDelegate.setPadding(left, top, right, bottom);
+        } else {
+            super.setPadding(left, top, right, bottom);
+        }
+    }
+
+    @Override
+    public void setPaddingRelative(int start, int top, int end, int bottom) {
+        if (mElevationDelegate != null) {
+            mElevationDelegate.setPaddingRelative(start, top, end, bottom);
+        } else {
+            super.setPaddingRelative(start, top, end, bottom);
+        }
+    }
+
+    @Override
+    public void superSetBackground(Drawable background) {
+        super.setBackground(background);
+    }
+
+    @Override
+    public void superSetPadding(int left, int top, int right, int bottom) {
+        super.setPadding(left, top, right, bottom);
+    }
+
+    @Override
+    public void setLayoutParams(ViewGroup.LayoutParams params) {
+        if (mElevationDelegate != null) {
+            mElevationDelegate.setLayoutParams(params);
+        } else {
+            super.setLayoutParams(params);
+        }
+    }
+
+    @Override
+    public void superSetLayoutParams(ViewGroup.LayoutParams params) {
+        super.setLayoutParams(params);
+    }
+
+    @Override
+    public int getPaddingLeft() {
+        if (mElevationDelegate != null) {
+            return mElevationDelegate.getUnshadowedPaddingLeft();
+        } else {
+            return super.getPaddingLeft();
+        }
+    }
+
+    @Override
+    public int getPaddingTop() {
+        if (mElevationDelegate != null) {
+            return mElevationDelegate.getUnshadowedPaddingTop();
+        } else {
+            return super.getPaddingTop();
+        }
+    }
+
+    @Override
+    public int getPaddingRight() {
+        if (mElevationDelegate != null) {
+            return mElevationDelegate.getUnshadowedPaddingRight();
+        } else {
+            return super.getPaddingRight();
+        }
+    }
+
+    @Override
+    public int getPaddingBottom() {
+        if (mElevationDelegate != null) {
+            return mElevationDelegate.getUnshadowedPaddingBottom();
+        } else {
+            return super.getPaddingBottom();
+        }
+    }
+
+    @Override
+    public int getPaddingStart() {
+        if (mElevationDelegate != null) {
+            return mElevationDelegate.getUnshadowedPaddingStart();
+        } else {
+            return super.getPaddingStart();
+        }
+    }
+
+    @Override
+    public int getPaddingEnd() {
+        if (mElevationDelegate != null) {
+            return mElevationDelegate.getUnshadowedPaddingEnd();
+        } else {
+            return super.getPaddingEnd();
+        }
+    }
+}

--- a/MaterialSamples/src/main/res/drawable/roundrect_sample.xml
+++ b/MaterialSamples/src/main/res/drawable/roundrect_sample.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+
+    <corners android:radius="9dip" />
+
+    <solid android:color="#ffffff" />
+
+</shape>

--- a/MaterialSamples/src/main/res/layout/activity_main.xml
+++ b/MaterialSamples/src/main/res/layout/activity_main.xml
@@ -20,6 +20,7 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:paddingBottom="600dip"
             android:orientation="vertical">
 
             <include layout="@layout/sample_material" />
@@ -29,6 +30,8 @@
         </LinearLayout>
 
     </ScrollView>
+
+    <include layout="@layout/sample_elevation" />
 
     <include layout="@layout/sample_fab" />
 

--- a/MaterialSamples/src/main/res/layout/sample_elevation.xml
+++ b/MaterialSamples/src/main/res/layout/sample_elevation.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="8dip"
+        android:background="@drawable/roundrect_sample"
+        android:layout_margin="16dip"
+        android:text="Lorem ipsum"
+        android:layout_gravity="center_vertical|start"
+        android:elevation="4dip" />
+
+    <io.doist.material.sample.ElevatedTextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="8dip"
+        android:background="@drawable/roundrect_sample"
+        android:layout_margin="16dip"
+        android:text="Lorem ipsum"
+        android:layout_gravity="center_vertical|end"
+        app:elevation="4dip"
+        app:cornerRadius="9dip" />
+
+</FrameLayout>

--- a/MaterialSamples/src/main/res/layout/sample_fab.xml
+++ b/MaterialSamples/src/main/res/layout/sample_fab.xml
@@ -7,18 +7,23 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="end|top"
+        android:layout_marginTop="@dimen/fab_default_margin"
+        android:layout_marginEnd="100dip"
+        android:layout_marginRight="100dip"
         android:color="@color/btn_sample"
         android:onClick="onFabClick"
+        app:inCompat="true"
         app:isMini="true" />
 
     <io.doist.material.widget.FloatingActionButton
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="end|top"
-        android:layout_marginRight="100dip"
+        android:layout_marginTop="@dimen/fab_default_margin"
+        android:layout_marginEnd="@dimen/fab_default_margin"
+        android:layout_marginRight="@dimen/fab_default_margin"
         android:color="@color/btn_sample"
         android:onClick="onFabClick"
-        app:inCompat="true"
         app:isMini="true" />
 
     <!-- Bottom FABs -->
@@ -26,17 +31,22 @@
     <io.doist.material.widget.FloatingActionButton
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="end|bottom"
-        android:onClick="onFabClick" />
+        android:layout_gravity="start|bottom"
+        android:layout_marginBottom="@dimen/fab_default_margin"
+        android:layout_marginStart="@dimen/fab_default_margin"
+        android:layout_marginLeft="@dimen/fab_default_margin"
+        android:onClick="onFabClick"
+        app:inCompat="true" />
 
     <io.doist.material.widget.FloatingActionButton
         android:id="@+id/fab"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="end|bottom"
-        android:layout_marginRight="140dip"
-        android:paddingRight="140dip"
+        android:layout_marginBottom="@dimen/fab_default_margin"
+        android:layout_marginEnd="@dimen/fab_default_margin"
+        android:layout_marginRight="@dimen/fab_default_margin"
         android:theme="@style/OverlayTheme"
-        app:inCompat="true" />
+        android:onClick="onFabClick" />
 
 </merge>


### PR DESCRIPTION
This PR adds elevation compat support in a flexible way via `ElevationDelegate`. It's close to the native implementation, handles the most common use cases like extra padding, margins, etc automatically and it's by far the most versatile approach I've seen so far (in some cases it's not closer to the native elevation on L due to this flexibility).

I strongly advise reading the JavaDoc of each class / method and looking at the samples, but here are some pointers:
1. `ElevationDelegate` should be created by the subclass view that needs elevation (eg. FloatingActionButton or ElevatedToolbar), and some of the methods need proxying (a few are mandatory, but there are others to ease the pain resulted from needing padding in pre-L);
2. `ElevationWrapperDrawable` is a drawables that wraps another drawable (the view's background) and draws the shadow. It has a few formulas based on ~~real shadow math~~ _some general math, some trial and error and a buttload of brute-forcing (using a script plus manually measured data)_ :smile: for calculating the shadow length and alpha in each direction;
3. `ElevationUpdateRunnable` does the heavy lifting of creating the all the edge shaders and corner alpha masks (bitmaps), and is generally run in a background thread after the first run. Initially there were no corner alpha masks -- I would simply draw the generated paths on the Canvas directly. However, this took 10x more time than generating the paths themselves.

![Native on the left, compat on the right](https://dl.dropboxusercontent.com/u/1585962/elevation.png)
