### PR TITLE
Math operands should be cast before assignment

### DIFF
--- a/MaterialLibrary/src/main/java/io/doist/material/drawable/RippleMaterialDrawable.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/drawable/RippleMaterialDrawable.java
@@ -189,7 +189,7 @@ public class RippleMaterialDrawable extends LayerMaterialDrawable {
             currentTime = Math.min(mShowRippleAnimator.getCurrentPlayTime(), mAnimationDuration / 2);
             mShowRippleAnimator.cancel();
         } else {
-            currentTime = mAnimationDuration / 2;
+            currentTime = mAnimationDuration / 2L;
         }
 
         Drawable rippleDrawable = getDrawableSafe(((RippleState) mLayerMaterialState).mRippleIndex);

--- a/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationUpdateRunnable.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/elevation/ElevationUpdateRunnable.java
@@ -109,12 +109,12 @@ class ElevationUpdateRunnable implements Runnable {
             edgeShaderTop = buildEdgeShader(0, mShadowLengthTop, 0, 0, mShadowAlphaTop);
         }
         if (mDirtyRight || mDirtyLeft) {
-            edgeShaderRight = buildEdgeShader(mShadowLengthLeft + width, 0,
-                                              mShadowLengthLeft + width + mShadowLengthRight, 0, mShadowAlphaRight);
+            edgeShaderRight = buildEdgeShader((float)mShadowLengthLeft + width, 0,
+                                              (float)mShadowLengthLeft + width + mShadowLengthRight, 0, mShadowAlphaRight);
         }
         if (mDirtyBottom || mDirtyTop) {
-            edgeShaderBottom = buildEdgeShader(0, mShadowLengthTop + height,
-                                               0, mShadowLengthTop + height + mShadowLengthBottom, mShadowAlphaBottom);
+            edgeShaderBottom = buildEdgeShader(0, (float)mShadowLengthTop + height,
+                                               0, (float)mShadowLengthTop + height + mShadowLengthBottom, mShadowAlphaBottom);
         }
 
         // Build corner gradients (1 per slice) and draw them. Each corner bitmap is an alpha mask.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S2184 Math operands should be cast before assignment

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2184

Please let me know if you have any questions.

Zeeshan Asghar
