### PR TITLE
General Code Improvement 1

### DIFF
--- a/MaterialLibrary/src/main/java/io/doist/material/drawable/RippleMaterialDrawable.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/drawable/RippleMaterialDrawable.java
@@ -55,6 +55,11 @@ public class RippleMaterialDrawable extends LayerMaterialDrawable {
         }
     }
 
+    RippleMaterialDrawable(LayerMaterialState state, Resources res) {
+        super(state, res);
+        setRippleIndex(((RippleState) mLayerMaterialState).mRippleIndex);
+    }
+
     /**
      * Creates a new color animation with the specified color and optional content.
      *
@@ -87,11 +92,6 @@ public class RippleMaterialDrawable extends LayerMaterialDrawable {
 
     static Drawable createRippleDrawable(Context context, ColorStateList color, Drawable content) {
         return new TintDrawable(context, content.getConstantState().newDrawable().mutate(), color);
-    }
-
-    RippleMaterialDrawable(LayerMaterialState state, Resources res) {
-        super(state, res);
-        setRippleIndex(((RippleState) mLayerMaterialState).mRippleIndex);
     }
 
     @Override

--- a/MaterialLibrary/src/main/java/io/doist/material/drawable/StateListMaterialDrawable.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/drawable/StateListMaterialDrawable.java
@@ -136,7 +136,7 @@ public class StateListMaterialDrawable extends StateListDrawable {
                 case android.R.attr.drawable:
                 case android.R.attr.id:
                     // Ignore attributes from StateListDrawableItem.
-                    continue;
+                    break;
                 default:
                     states[j++] = attrs.getAttributeBooleanValue(i, false)
                                   ? stateResId : -stateResId;

--- a/MaterialLibrary/src/main/java/io/doist/material/drawable/TintDrawable.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/drawable/TintDrawable.java
@@ -37,6 +37,13 @@ public class TintDrawable extends WrapperDrawable {
         this(context, drawable, null);
     }
 
+    protected TintDrawable(TintState state, Resources res) {
+        super(state, res);
+        mTintState = (TintState) getConstantState();
+        updateTint();
+        updateAlpha();
+    }
+
     public TintDrawable(Context context, Drawable drawable, int tint) {
         this(context, drawable, ColorStateList.valueOf(tint));
     }
@@ -235,10 +242,4 @@ public class TintDrawable extends WrapperDrawable {
         }
     }
 
-    protected TintDrawable(TintState state, Resources res) {
-        super(state, res);
-        mTintState = (TintState) getConstantState();
-        updateTint();
-        updateAlpha();
-    }
 }

--- a/MaterialLibrary/src/main/java/io/doist/material/drawable/WrapperDrawable.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/drawable/WrapperDrawable.java
@@ -27,6 +27,18 @@ public class WrapperDrawable extends Drawable implements Drawable.Callback {
         setWrappedDrawable(drawable);
     }
 
+    protected WrapperDrawable(WrapperState state, Resources res) {
+        mWrapperState = createConstantState(state);
+
+        final Drawable drawable;
+        if (res != null) {
+            drawable = mWrapperState.mDrawable.getConstantState().newDrawable(res);
+        } else {
+            drawable = mWrapperState.mDrawable.getConstantState().newDrawable();
+        }
+        mWrapperState.setDrawable(drawable, this);
+    }
+
     public void setWrappedDrawable(Drawable drawable) {
         if (mWrapperState.mDrawable != null) {
             mWrapperState.mDrawable.setCallback(null);
@@ -276,18 +288,6 @@ public class WrapperDrawable extends Drawable implements Drawable.Callback {
         protected boolean canConstantState() {
             return mDrawable.getConstantState() != null;
         }
-    }
-
-    protected WrapperDrawable(WrapperState state, Resources res) {
-        mWrapperState = createConstantState(state);
-
-        final Drawable drawable;
-        if (res != null) {
-            drawable = mWrapperState.mDrawable.getConstantState().newDrawable(res);
-        } else {
-            drawable = mWrapperState.mDrawable.getConstantState().newDrawable();
-        }
-        mWrapperState.setDrawable(drawable, this);
     }
 
     /*

--- a/MaterialLibrary/src/main/java/io/doist/material/res/MaterialResources.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/res/MaterialResources.java
@@ -34,6 +34,23 @@ public class MaterialResources {
     private LongSparseArray<WeakReference<Drawable.ConstantState>> mDrawableCache;
     private LongSparseArray<WeakReference<Drawable.ConstantState>> mColorDrawableCache;
 
+    public static int[] CONFIG_NATIVE_BITS = new int[]{
+            MaterialConfiguration.NATIVE_CONFIG_MNC,                    // MNC
+            MaterialConfiguration.NATIVE_CONFIG_MCC,                    // MCC
+            MaterialConfiguration.NATIVE_CONFIG_LOCALE,                 // LOCALE
+            MaterialConfiguration.NATIVE_CONFIG_TOUCHSCREEN,            // TOUCH SCREEN
+            MaterialConfiguration.NATIVE_CONFIG_KEYBOARD,               // KEYBOARD
+            MaterialConfiguration.NATIVE_CONFIG_KEYBOARD_HIDDEN,        // KEYBOARD HIDDEN
+            MaterialConfiguration.NATIVE_CONFIG_NAVIGATION,             // NAVIGATION
+            MaterialConfiguration.NATIVE_CONFIG_ORIENTATION,            // ORIENTATION
+            MaterialConfiguration.NATIVE_CONFIG_SCREEN_LAYOUT,          // SCREEN LAYOUT
+            MaterialConfiguration.NATIVE_CONFIG_UI_MODE,                // UI MODE
+            MaterialConfiguration.NATIVE_CONFIG_SCREEN_SIZE,            // SCREEN SIZE
+            MaterialConfiguration.NATIVE_CONFIG_SMALLEST_SCREEN_SIZE,   // SMALLEST SCREEN SIZE
+            MaterialConfiguration.NATIVE_CONFIG_DENSITY,                // DENSITY
+            MaterialConfiguration.NATIVE_CONFIG_LAYOUTDIR,              // LAYOUT DIRECTION
+    };
+
     public static MaterialResources getInstance(Context context, Resources resources) {
         int themeResId = getThemeResId(context);
         MaterialResources instance = sInstances.get(themeResId);
@@ -271,23 +288,6 @@ public class MaterialResources {
             }
         }
     }
-
-    public static int[] CONFIG_NATIVE_BITS = new int[]{
-            MaterialConfiguration.NATIVE_CONFIG_MNC,                    // MNC
-            MaterialConfiguration.NATIVE_CONFIG_MCC,                    // MCC
-            MaterialConfiguration.NATIVE_CONFIG_LOCALE,                 // LOCALE
-            MaterialConfiguration.NATIVE_CONFIG_TOUCHSCREEN,            // TOUCH SCREEN
-            MaterialConfiguration.NATIVE_CONFIG_KEYBOARD,               // KEYBOARD
-            MaterialConfiguration.NATIVE_CONFIG_KEYBOARD_HIDDEN,        // KEYBOARD HIDDEN
-            MaterialConfiguration.NATIVE_CONFIG_NAVIGATION,             // NAVIGATION
-            MaterialConfiguration.NATIVE_CONFIG_ORIENTATION,            // ORIENTATION
-            MaterialConfiguration.NATIVE_CONFIG_SCREEN_LAYOUT,          // SCREEN LAYOUT
-            MaterialConfiguration.NATIVE_CONFIG_UI_MODE,                // UI MODE
-            MaterialConfiguration.NATIVE_CONFIG_SCREEN_SIZE,            // SCREEN SIZE
-            MaterialConfiguration.NATIVE_CONFIG_SMALLEST_SCREEN_SIZE,   // SMALLEST SCREEN SIZE
-            MaterialConfiguration.NATIVE_CONFIG_DENSITY,                // DENSITY
-            MaterialConfiguration.NATIVE_CONFIG_LAYOUTDIR,              // LAYOUT DIRECTION
-    };
 
     private static class MaterialConfiguration {
         /** Configuration.KEYBOARDHIDDEN_SOFT is hidden */


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S128 Switch cases should end with an unconditional 'break' statement
squid:S1213 The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S128 
https://dev.eclipse.org/sonar/rules/show/squid:S1213 

Please let me know if you have any questions.

Zeeshan Asghar
