### PR TITLE
Tint drawables after initialization

### DIFF
--- a/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialAutoCompleteTextView.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialAutoCompleteTextView.java
@@ -1,12 +1,17 @@
 package io.doist.material.widget;
 
+import android.annotation.TargetApi;
 import android.content.Context;
+import android.os.Build;
+import android.support.annotation.DrawableRes;
 import android.util.AttributeSet;
 import android.widget.AutoCompleteTextView;
 
 import io.doist.material.widget.utils.MaterialWidgetHandler;
 
 public class MaterialAutoCompleteTextView extends AutoCompleteTextView {
+    private static final boolean sNative = Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT;
+
     private static final MaterialWidgetHandler.Styleable[] sHiddenStyleables = {
             MaterialWidgetHandler.Styleable.TEXT_VIEW,
             MaterialWidgetHandler.Styleable.VIEW
@@ -25,5 +30,39 @@ public class MaterialAutoCompleteTextView extends AutoCompleteTextView {
               MaterialWidgetHandler.hideStyleableAttributes(attrs, sHiddenStyleables), defStyle);
         MaterialWidgetHandler.restoreStyleableAttributes(sHiddenStyleables);
         MaterialWidgetHandler.init(this, attrs, defStyle, sHiddenStyleables);
+    }
+
+    @Override
+    public void setCompoundDrawablesWithIntrinsicBounds(@DrawableRes int left, @DrawableRes int top,
+                                                        @DrawableRes int right, @DrawableRes int bottom) {
+        if (sNative) {
+            super.setCompoundDrawablesWithIntrinsicBounds(left, top, right, bottom);
+        } else {
+            super.setCompoundDrawablesWithIntrinsicBounds(
+                    MaterialWidgetHandler.getDrawable(this, left), MaterialWidgetHandler.getDrawable(this, top),
+                    MaterialWidgetHandler.getDrawable(this, right), MaterialWidgetHandler.getDrawable(this, bottom));
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+    @Override
+    public void setCompoundDrawablesRelativeWithIntrinsicBounds(@DrawableRes int start, @DrawableRes int top,
+                                                                @DrawableRes int end, @DrawableRes int bottom) {
+        if (sNative) {
+            super.setCompoundDrawablesRelativeWithIntrinsicBounds(start, top, end, bottom);
+        } else {
+            super.setCompoundDrawablesRelativeWithIntrinsicBounds(
+                    MaterialWidgetHandler.getDrawable(this, start), MaterialWidgetHandler.getDrawable(this, top),
+                    MaterialWidgetHandler.getDrawable(this, end), MaterialWidgetHandler.getDrawable(this, bottom));
+        }
+    }
+
+    @Override
+    public void setBackgroundResource(@DrawableRes int resId) {
+        if (sNative) {
+            super.setBackgroundResource(resId);
+        } else {
+            super.setBackground(MaterialWidgetHandler.getDrawable(this, resId));
+        }
     }
 }

--- a/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialButton.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialButton.java
@@ -1,12 +1,16 @@
 package io.doist.material.widget;
 
 import android.content.Context;
+import android.os.Build;
+import android.support.annotation.DrawableRes;
 import android.util.AttributeSet;
 import android.widget.Button;
 
 import io.doist.material.widget.utils.MaterialWidgetHandler;
 
 public class MaterialButton extends Button {
+    private static final boolean sNative = Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT;
+
     private static final MaterialWidgetHandler.Styleable[] sHiddenStyleables = {
             MaterialWidgetHandler.Styleable.VIEW
     };
@@ -24,5 +28,14 @@ public class MaterialButton extends Button {
               MaterialWidgetHandler.hideStyleableAttributes(attrs, sHiddenStyleables), defStyle);
         MaterialWidgetHandler.restoreStyleableAttributes(sHiddenStyleables);
         MaterialWidgetHandler.init(this, attrs, defStyle, sHiddenStyleables);
+    }
+
+    @Override
+    public void setBackgroundResource(@DrawableRes int resId) {
+        if (sNative) {
+            super.setBackgroundResource(resId);
+        } else {
+            super.setBackground(MaterialWidgetHandler.getDrawable(this, resId));
+        }
     }
 }

--- a/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialCheckBox.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialCheckBox.java
@@ -1,12 +1,17 @@
 package io.doist.material.widget;
 
+import android.annotation.TargetApi;
 import android.content.Context;
+import android.os.Build;
+import android.support.annotation.DrawableRes;
 import android.util.AttributeSet;
 import android.widget.CheckBox;
 
 import io.doist.material.widget.utils.MaterialWidgetHandler;
 
 public class MaterialCheckBox extends CheckBox {
+    private static final boolean sNative = Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT;
+
     private static final MaterialWidgetHandler.Styleable[] sHiddenStyleables = {
             MaterialWidgetHandler.Styleable.COMPOUND_BUTTON,
             MaterialWidgetHandler.Styleable.TEXT_VIEW,
@@ -26,5 +31,48 @@ public class MaterialCheckBox extends CheckBox {
               MaterialWidgetHandler.hideStyleableAttributes(attrs, sHiddenStyleables), defStyle);
         MaterialWidgetHandler.restoreStyleableAttributes(sHiddenStyleables);
         MaterialWidgetHandler.init(this, attrs, defStyle, sHiddenStyleables);
+    }
+
+    @Override
+    public void setButtonDrawable(@DrawableRes int resId) {
+        if (sNative) {
+            super.setButtonDrawable(resId);
+        } else {
+            super.setButtonDrawable(MaterialWidgetHandler.getDrawable(this, resId));
+        }
+    }
+
+    @Override
+    public void setCompoundDrawablesWithIntrinsicBounds(@DrawableRes int left, @DrawableRes int top,
+                                                        @DrawableRes int right, @DrawableRes int bottom) {
+        if (sNative) {
+            super.setCompoundDrawablesWithIntrinsicBounds(left, top, right, bottom);
+        } else {
+            super.setCompoundDrawablesWithIntrinsicBounds(
+                    MaterialWidgetHandler.getDrawable(this, left), MaterialWidgetHandler.getDrawable(this, top),
+                    MaterialWidgetHandler.getDrawable(this, right), MaterialWidgetHandler.getDrawable(this, bottom));
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+    @Override
+    public void setCompoundDrawablesRelativeWithIntrinsicBounds(@DrawableRes int start, @DrawableRes int top,
+                                                                @DrawableRes int end, @DrawableRes int bottom) {
+        if (sNative) {
+            super.setCompoundDrawablesRelativeWithIntrinsicBounds(start, top, end, bottom);
+        } else {
+            super.setCompoundDrawablesRelativeWithIntrinsicBounds(
+                    MaterialWidgetHandler.getDrawable(this, start), MaterialWidgetHandler.getDrawable(this, top),
+                    MaterialWidgetHandler.getDrawable(this, end), MaterialWidgetHandler.getDrawable(this, bottom));
+        }
+    }
+
+    @Override
+    public void setBackgroundResource(@DrawableRes int resId) {
+        if (sNative) {
+            super.setBackgroundResource(resId);
+        } else {
+            super.setBackground(MaterialWidgetHandler.getDrawable(this, resId));
+        }
     }
 }

--- a/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialCheckedTextView.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialCheckedTextView.java
@@ -1,13 +1,18 @@
 package io.doist.material.widget;
 
+import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
+import android.support.annotation.DrawableRes;
 import android.util.AttributeSet;
 import android.widget.CheckedTextView;
 
 import io.doist.material.widget.utils.MaterialWidgetHandler;
 
 public class MaterialCheckedTextView extends CheckedTextView {
+    private static final boolean sNative = Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT;
+
     private static final MaterialWidgetHandler.Styleable[] sHiddenStyleables = {
             MaterialWidgetHandler.Styleable.CHECKED_TEXT_VIEW,
             MaterialWidgetHandler.Styleable.TEXT_VIEW,
@@ -18,8 +23,10 @@ public class MaterialCheckedTextView extends CheckedTextView {
         this(context, null);
     }
 
+    @SuppressLint("InlinedApi")
     public MaterialCheckedTextView(Context context, AttributeSet attrs) {
-        this(context, attrs, getDefStyle());
+        this(context, attrs,
+             Build.VERSION.SDK_INT > Build.VERSION_CODES.JELLY_BEAN ? android.R.attr.checkedTextViewStyle : 0);
     }
 
     public MaterialCheckedTextView(Context context, AttributeSet attrs, int defStyle) {
@@ -29,11 +36,46 @@ public class MaterialCheckedTextView extends CheckedTextView {
         MaterialWidgetHandler.init(this, attrs, defStyle, sHiddenStyleables);
     }
 
-    private static int getDefStyle() {
-        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.JELLY_BEAN) {
-            return android.R.attr.checkedTextViewStyle;
+    @Override
+    public void setCheckMarkDrawable(@DrawableRes int resId) {
+        if (sNative) {
+            super.setCheckMarkDrawable(resId);
         } else {
-            return 0;
+            super.setCheckMarkDrawable(MaterialWidgetHandler.getDrawable(this, resId));
+        }
+    }
+
+    @Override
+    public void setCompoundDrawablesWithIntrinsicBounds(@DrawableRes int left, @DrawableRes int top,
+                                                        @DrawableRes int right, @DrawableRes int bottom) {
+        if (sNative) {
+            super.setCompoundDrawablesWithIntrinsicBounds(left, top, right, bottom);
+        } else {
+            super.setCompoundDrawablesWithIntrinsicBounds(
+                    MaterialWidgetHandler.getDrawable(this, left), MaterialWidgetHandler.getDrawable(this, top),
+                    MaterialWidgetHandler.getDrawable(this, right), MaterialWidgetHandler.getDrawable(this, bottom));
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+    @Override
+    public void setCompoundDrawablesRelativeWithIntrinsicBounds(@DrawableRes int start, @DrawableRes int top,
+                                                                @DrawableRes int end, @DrawableRes int bottom) {
+        if (sNative) {
+            super.setCompoundDrawablesRelativeWithIntrinsicBounds(start, top, end, bottom);
+        } else {
+            super.setCompoundDrawablesRelativeWithIntrinsicBounds(
+                    MaterialWidgetHandler.getDrawable(this, start), MaterialWidgetHandler.getDrawable(this, top),
+                    MaterialWidgetHandler.getDrawable(this, end), MaterialWidgetHandler.getDrawable(this, bottom));
+        }
+    }
+
+    @Override
+    public void setBackgroundResource(@DrawableRes int resId) {
+        if (sNative) {
+            super.setBackgroundResource(resId);
+        } else {
+            super.setBackground(MaterialWidgetHandler.getDrawable(this, resId));
         }
     }
 }

--- a/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialEditText.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialEditText.java
@@ -1,12 +1,17 @@
 package io.doist.material.widget;
 
+import android.annotation.TargetApi;
 import android.content.Context;
+import android.os.Build;
+import android.support.annotation.DrawableRes;
 import android.util.AttributeSet;
 import android.widget.EditText;
 
 import io.doist.material.widget.utils.MaterialWidgetHandler;
 
 public class MaterialEditText extends EditText {
+    private static final boolean sNative = Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT;
+
     private static final MaterialWidgetHandler.Styleable[] sHiddenStyleables = {
             MaterialWidgetHandler.Styleable.TEXT_VIEW,
             MaterialWidgetHandler.Styleable.VIEW
@@ -25,5 +30,39 @@ public class MaterialEditText extends EditText {
               MaterialWidgetHandler.hideStyleableAttributes(attrs, sHiddenStyleables), defStyle);
         MaterialWidgetHandler.restoreStyleableAttributes(sHiddenStyleables);
         MaterialWidgetHandler.init(this, attrs, defStyle, sHiddenStyleables);
+    }
+
+    @Override
+    public void setCompoundDrawablesWithIntrinsicBounds(@DrawableRes int left, @DrawableRes int top,
+                                                        @DrawableRes int right, @DrawableRes int bottom) {
+        if (sNative) {
+            super.setCompoundDrawablesWithIntrinsicBounds(left, top, right, bottom);
+        } else {
+            super.setCompoundDrawablesWithIntrinsicBounds(
+                    MaterialWidgetHandler.getDrawable(this, left), MaterialWidgetHandler.getDrawable(this, top),
+                    MaterialWidgetHandler.getDrawable(this, right), MaterialWidgetHandler.getDrawable(this, bottom));
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+    @Override
+    public void setCompoundDrawablesRelativeWithIntrinsicBounds(@DrawableRes int start, @DrawableRes int top,
+                                                                @DrawableRes int end, @DrawableRes int bottom) {
+        if (sNative) {
+            super.setCompoundDrawablesRelativeWithIntrinsicBounds(start, top, end, bottom);
+        } else {
+            super.setCompoundDrawablesRelativeWithIntrinsicBounds(
+                    MaterialWidgetHandler.getDrawable(this, start), MaterialWidgetHandler.getDrawable(this, top),
+                    MaterialWidgetHandler.getDrawable(this, end), MaterialWidgetHandler.getDrawable(this, bottom));
+        }
+    }
+
+    @Override
+    public void setBackgroundResource(@DrawableRes int resId) {
+        if (sNative) {
+            super.setBackgroundResource(resId);
+        } else {
+            super.setBackground(MaterialWidgetHandler.getDrawable(this, resId));
+        }
     }
 }

--- a/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialFrameLayout.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialFrameLayout.java
@@ -1,12 +1,16 @@
 package io.doist.material.widget;
 
 import android.content.Context;
+import android.os.Build;
+import android.support.annotation.DrawableRes;
 import android.util.AttributeSet;
 import android.widget.FrameLayout;
 
 import io.doist.material.widget.utils.MaterialWidgetHandler;
 
 public class MaterialFrameLayout extends FrameLayout {
+    private static final boolean sNative = Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT;
+
     private static final MaterialWidgetHandler.Styleable[] sHiddenStyleables = {
             MaterialWidgetHandler.Styleable.VIEW,
             MaterialWidgetHandler.Styleable.FRAME_LAYOUT
@@ -25,5 +29,14 @@ public class MaterialFrameLayout extends FrameLayout {
               MaterialWidgetHandler.hideStyleableAttributes(attrs, sHiddenStyleables), defStyle);
         MaterialWidgetHandler.restoreStyleableAttributes(sHiddenStyleables);
         MaterialWidgetHandler.init(this, attrs, defStyle, sHiddenStyleables);
+    }
+
+    @Override
+    public void setBackgroundResource(@DrawableRes int resId) {
+        if (sNative) {
+            super.setBackgroundResource(resId);
+        } else {
+            super.setBackground(MaterialWidgetHandler.getDrawable(this, resId));
+        }
     }
 }

--- a/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialImageButton.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialImageButton.java
@@ -1,12 +1,16 @@
 package io.doist.material.widget;
 
 import android.content.Context;
+import android.os.Build;
+import android.support.annotation.DrawableRes;
 import android.util.AttributeSet;
 import android.widget.ImageButton;
 
 import io.doist.material.widget.utils.MaterialWidgetHandler;
 
 public class MaterialImageButton extends ImageButton {
+    private static final boolean sNative = Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT;
+
     private static final MaterialWidgetHandler.Styleable[] sHiddenStyleables = {
             MaterialWidgetHandler.Styleable.VIEW,
             MaterialWidgetHandler.Styleable.IMAGE_VIEW
@@ -25,5 +29,23 @@ public class MaterialImageButton extends ImageButton {
               MaterialWidgetHandler.hideStyleableAttributes(attrs, sHiddenStyleables), defStyle);
         MaterialWidgetHandler.restoreStyleableAttributes(sHiddenStyleables);
         MaterialWidgetHandler.init(this, attrs, defStyle, sHiddenStyleables);
+    }
+
+    @Override
+    public void setBackgroundResource(@DrawableRes int resId) {
+        if (sNative) {
+            super.setBackgroundResource(resId);
+        } else {
+            super.setBackground(MaterialWidgetHandler.getDrawable(this, resId));
+        }
+    }
+
+    @Override
+    public void setImageResource(@DrawableRes int resId) {
+        if (sNative) {
+            super.setImageResource(resId);
+        } else {
+            super.setImageDrawable(MaterialWidgetHandler.getDrawable(this, resId));
+        }
     }
 }

--- a/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialImageView.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialImageView.java
@@ -1,12 +1,16 @@
 package io.doist.material.widget;
 
 import android.content.Context;
+import android.os.Build;
+import android.support.annotation.DrawableRes;
 import android.util.AttributeSet;
 import android.widget.ImageView;
 
 import io.doist.material.widget.utils.MaterialWidgetHandler;
 
 public class MaterialImageView extends ImageView {
+    private static final boolean sNative = Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT;
+
     private static final MaterialWidgetHandler.Styleable[] sHiddenStyleables = {
             MaterialWidgetHandler.Styleable.VIEW,
             MaterialWidgetHandler.Styleable.IMAGE_VIEW
@@ -25,5 +29,23 @@ public class MaterialImageView extends ImageView {
               MaterialWidgetHandler.hideStyleableAttributes(attrs, sHiddenStyleables), defStyle);
         MaterialWidgetHandler.restoreStyleableAttributes(sHiddenStyleables);
         MaterialWidgetHandler.init(this, attrs, defStyle, sHiddenStyleables);
+    }
+
+    @Override
+    public void setBackgroundResource(@DrawableRes int resId) {
+        if (sNative) {
+            super.setBackgroundResource(resId);
+        } else {
+            super.setBackground(MaterialWidgetHandler.getDrawable(this, resId));
+        }
+    }
+
+    @Override
+    public void setImageResource(@DrawableRes int resId) {
+        if (sNative) {
+            super.setImageResource(resId);
+        } else {
+            super.setImageDrawable(MaterialWidgetHandler.getDrawable(this, resId));
+        }
     }
 }

--- a/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialLinearLayout.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialLinearLayout.java
@@ -1,12 +1,16 @@
 package io.doist.material.widget;
 
 import android.content.Context;
+import android.os.Build;
+import android.support.annotation.DrawableRes;
 import android.util.AttributeSet;
 import android.widget.LinearLayout;
 
 import io.doist.material.widget.utils.MaterialWidgetHandler;
 
 public class MaterialLinearLayout extends LinearLayout {
+    private static final boolean sNative = Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT;
+
     private static final MaterialWidgetHandler.Styleable[] sHiddenStyleables = {
             MaterialWidgetHandler.Styleable.VIEW
     };
@@ -24,5 +28,14 @@ public class MaterialLinearLayout extends LinearLayout {
               MaterialWidgetHandler.hideStyleableAttributes(attrs, sHiddenStyleables), defStyle);
         MaterialWidgetHandler.restoreStyleableAttributes(sHiddenStyleables);
         MaterialWidgetHandler.init(this, attrs, defStyle, sHiddenStyleables);
+    }
+
+    @Override
+    public void setBackgroundResource(@DrawableRes int resId) {
+        if (sNative) {
+            super.setBackgroundResource(resId);
+        } else {
+            super.setBackground(MaterialWidgetHandler.getDrawable(this, resId));
+        }
     }
 }

--- a/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialRadioButton.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialRadioButton.java
@@ -1,12 +1,17 @@
 package io.doist.material.widget;
 
+import android.annotation.TargetApi;
 import android.content.Context;
+import android.os.Build;
+import android.support.annotation.DrawableRes;
 import android.util.AttributeSet;
 import android.widget.RadioButton;
 
 import io.doist.material.widget.utils.MaterialWidgetHandler;
 
 public class MaterialRadioButton extends RadioButton {
+    private static final boolean sNative = Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT;
+
     private static final MaterialWidgetHandler.Styleable[] sHiddenStyleables = {
             MaterialWidgetHandler.Styleable.COMPOUND_BUTTON,
             MaterialWidgetHandler.Styleable.TEXT_VIEW,
@@ -26,5 +31,46 @@ public class MaterialRadioButton extends RadioButton {
               MaterialWidgetHandler.hideStyleableAttributes(attrs, sHiddenStyleables), defStyle);
         MaterialWidgetHandler.restoreStyleableAttributes(sHiddenStyleables);
         MaterialWidgetHandler.init(this, attrs, defStyle, sHiddenStyleables);
+    }
+
+    @Override
+    public void setButtonDrawable(@DrawableRes int resId) {
+        if (sNative) {
+            super.setButtonDrawable(resId);
+        } else {
+            super.setButtonDrawable(MaterialWidgetHandler.getDrawable(this, resId));
+        }
+    }
+
+    @Override
+    public void setCompoundDrawablesWithIntrinsicBounds(@DrawableRes int left, @DrawableRes int top, @DrawableRes int right, @DrawableRes int bottom) {
+        if (sNative) {
+            super.setCompoundDrawablesWithIntrinsicBounds(left, top, right, bottom);
+        } else {
+            super.setCompoundDrawablesWithIntrinsicBounds(
+                    MaterialWidgetHandler.getDrawable(this, left), MaterialWidgetHandler.getDrawable(this, top),
+                    MaterialWidgetHandler.getDrawable(this, right), MaterialWidgetHandler.getDrawable(this, bottom));
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+    @Override
+    public void setCompoundDrawablesRelativeWithIntrinsicBounds(@DrawableRes int start, @DrawableRes int top, @DrawableRes int end, @DrawableRes int bottom) {
+        if (sNative) {
+            super.setCompoundDrawablesRelativeWithIntrinsicBounds(start, top, end, bottom);
+        } else {
+            super.setCompoundDrawablesRelativeWithIntrinsicBounds(
+                    MaterialWidgetHandler.getDrawable(this, start), MaterialWidgetHandler.getDrawable(this, top),
+                    MaterialWidgetHandler.getDrawable(this, end), MaterialWidgetHandler.getDrawable(this, bottom));
+        }
+    }
+
+    @Override
+    public void setBackgroundResource(@DrawableRes int resId) {
+        if (sNative) {
+            super.setBackgroundResource(resId);
+        } else {
+            super.setBackground(MaterialWidgetHandler.getDrawable(this, resId));
+        }
     }
 }

--- a/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialRelativeLayout.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialRelativeLayout.java
@@ -1,12 +1,16 @@
 package io.doist.material.widget;
 
 import android.content.Context;
+import android.os.Build;
+import android.support.annotation.DrawableRes;
 import android.util.AttributeSet;
 import android.widget.RelativeLayout;
 
 import io.doist.material.widget.utils.MaterialWidgetHandler;
 
 public class MaterialRelativeLayout extends RelativeLayout {
+    private static final boolean sNative = Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT;
+
     private static final MaterialWidgetHandler.Styleable[] sHiddenStyleables = {
             MaterialWidgetHandler.Styleable.VIEW
     };
@@ -24,5 +28,14 @@ public class MaterialRelativeLayout extends RelativeLayout {
               MaterialWidgetHandler.hideStyleableAttributes(attrs, sHiddenStyleables), defStyle);
         MaterialWidgetHandler.restoreStyleableAttributes(sHiddenStyleables);
         MaterialWidgetHandler.init(this, attrs, defStyle, sHiddenStyleables);
+    }
+
+    @Override
+    public void setBackgroundResource(@DrawableRes int resId) {
+        if (sNative) {
+            super.setBackgroundResource(resId);
+        } else {
+            super.setBackground(MaterialWidgetHandler.getDrawable(this, resId));
+        }
     }
 }

--- a/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialSpinner.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialSpinner.java
@@ -1,15 +1,18 @@
 package io.doist.material.widget;
 
 import android.content.Context;
+import android.os.Build;
+import android.support.annotation.DrawableRes;
 import android.support.v7.widget.AppCompatSpinner;
 import android.util.AttributeSet;
 
 import io.doist.material.widget.utils.MaterialWidgetHandler;
 
 public class MaterialSpinner extends AppCompatSpinner {
+    private static final boolean sNative = Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT;
+
     private static final MaterialWidgetHandler.Styleable[] sHiddenStyleables = {
             MaterialWidgetHandler.Styleable.VIEW,
-            MaterialWidgetHandler.Styleable.POPUP_WINDOW,
             MaterialWidgetHandler.Styleable.SPINNER
     };
 
@@ -34,5 +37,23 @@ public class MaterialSpinner extends AppCompatSpinner {
               MaterialWidgetHandler.hideStyleableAttributes(attrs, sHiddenStyleables), defStyle, mode);
         MaterialWidgetHandler.restoreStyleableAttributes(sHiddenStyleables);
         MaterialWidgetHandler.init(this, attrs, defStyle, sHiddenStyleables);
+    }
+
+    @Override
+    public void setBackgroundResource(@DrawableRes int resId) {
+        if (sNative) {
+            super.setBackgroundResource(resId);
+        } else {
+            super.setBackground(MaterialWidgetHandler.getDrawable(this, resId));
+        }
+    }
+
+    @Override
+    public void setPopupBackgroundResource(@DrawableRes int resId) {
+        if (sNative) {
+            super.setPopupBackgroundResource(resId);
+        } else {
+            super.setPopupBackgroundDrawable(MaterialWidgetHandler.getDrawable(this, resId));
+        }
     }
 }

--- a/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialSwitch.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialSwitch.java
@@ -1,6 +1,8 @@
 package io.doist.material.widget;
 
 import android.content.Context;
+import android.os.Build;
+import android.support.annotation.DrawableRes;
 import android.support.v7.widget.SwitchCompat;
 import android.util.AttributeSet;
 
@@ -8,6 +10,8 @@ import io.doist.material.R;
 import io.doist.material.widget.utils.MaterialWidgetHandler;
 
 public class MaterialSwitch extends SwitchCompat {
+    private static final boolean sNative = Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT;
+
     private static final MaterialWidgetHandler.Styleable[] sHiddenStyleables = {
             MaterialWidgetHandler.Styleable.VIEW
     };
@@ -25,5 +29,14 @@ public class MaterialSwitch extends SwitchCompat {
               MaterialWidgetHandler.hideStyleableAttributes(attrs, sHiddenStyleables), defStyle);
         MaterialWidgetHandler.restoreStyleableAttributes(sHiddenStyleables);
         MaterialWidgetHandler.init(this, attrs, defStyle, sHiddenStyleables);
+    }
+
+    @Override
+    public void setBackgroundResource(@DrawableRes int resId) {
+        if (sNative) {
+            super.setBackgroundResource(resId);
+        } else {
+            super.setBackground(MaterialWidgetHandler.getDrawable(this, resId));
+        }
     }
 }

--- a/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialTextView.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialTextView.java
@@ -1,12 +1,17 @@
 package io.doist.material.widget;
 
+import android.annotation.TargetApi;
 import android.content.Context;
+import android.os.Build;
+import android.support.annotation.DrawableRes;
 import android.util.AttributeSet;
 import android.widget.TextView;
 
 import io.doist.material.widget.utils.MaterialWidgetHandler;
 
 public class MaterialTextView extends TextView {
+    private static final boolean sNative = Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT;
+
     private static final MaterialWidgetHandler.Styleable[] sHiddenStyleables = {
             MaterialWidgetHandler.Styleable.TEXT_VIEW,
             MaterialWidgetHandler.Styleable.VIEW
@@ -25,5 +30,39 @@ public class MaterialTextView extends TextView {
               MaterialWidgetHandler.hideStyleableAttributes(attrs, sHiddenStyleables), defStyle);
         MaterialWidgetHandler.restoreStyleableAttributes(sHiddenStyleables);
         MaterialWidgetHandler.init(this, attrs, defStyle, sHiddenStyleables);
+    }
+
+    @Override
+    public void setCompoundDrawablesWithIntrinsicBounds(@DrawableRes int left, @DrawableRes int top,
+                                                        @DrawableRes int right, @DrawableRes int bottom) {
+        if (sNative) {
+            super.setCompoundDrawablesWithIntrinsicBounds(left, top, right, bottom);
+        } else {
+            super.setCompoundDrawablesWithIntrinsicBounds(
+                    MaterialWidgetHandler.getDrawable(this, left), MaterialWidgetHandler.getDrawable(this, top),
+                    MaterialWidgetHandler.getDrawable(this, right), MaterialWidgetHandler.getDrawable(this, bottom));
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+    @Override
+    public void setCompoundDrawablesRelativeWithIntrinsicBounds(@DrawableRes int start, @DrawableRes int top,
+                                                                @DrawableRes int end, @DrawableRes int bottom) {
+        if (sNative) {
+            super.setCompoundDrawablesRelativeWithIntrinsicBounds(start, top, end, bottom);
+        } else {
+            super.setCompoundDrawablesRelativeWithIntrinsicBounds(
+                    MaterialWidgetHandler.getDrawable(this, start), MaterialWidgetHandler.getDrawable(this, top),
+                    MaterialWidgetHandler.getDrawable(this, end), MaterialWidgetHandler.getDrawable(this, bottom));
+        }
+    }
+
+    @Override
+    public void setBackgroundResource(@DrawableRes int resId) {
+        if (sNative) {
+            super.setBackgroundResource(resId);
+        } else {
+            super.setBackground(MaterialWidgetHandler.getDrawable(this, resId));
+        }
     }
 }

--- a/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialToggleButton.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialToggleButton.java
@@ -1,12 +1,16 @@
 package io.doist.material.widget;
 
 import android.content.Context;
+import android.os.Build;
+import android.support.annotation.DrawableRes;
 import android.util.AttributeSet;
 import android.widget.ToggleButton;
 
 import io.doist.material.widget.utils.MaterialWidgetHandler;
 
 public class MaterialToggleButton extends ToggleButton {
+    private static final boolean sNative = Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT;
+
     private static final MaterialWidgetHandler.Styleable[] sHiddenStyleables = {
             MaterialWidgetHandler.Styleable.VIEW
     };
@@ -24,5 +28,14 @@ public class MaterialToggleButton extends ToggleButton {
               MaterialWidgetHandler.hideStyleableAttributes(attrs, sHiddenStyleables), defStyle);
         MaterialWidgetHandler.restoreStyleableAttributes(sHiddenStyleables);
         MaterialWidgetHandler.init(this, attrs, defStyle, sHiddenStyleables);
+    }
+
+    @Override
+    public void setBackgroundResource(@DrawableRes int resId) {
+        if(sNative) {
+            super.setBackgroundResource(resId);
+        } else {
+            super.setBackground(MaterialWidgetHandler.getDrawable(this, resId));
+        }
     }
 }

--- a/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialView.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/widget/MaterialView.java
@@ -1,12 +1,16 @@
 package io.doist.material.widget;
 
 import android.content.Context;
+import android.os.Build;
+import android.support.annotation.DrawableRes;
 import android.util.AttributeSet;
 import android.view.View;
 
 import io.doist.material.widget.utils.MaterialWidgetHandler;
 
 public class MaterialView extends View {
+    private static final boolean sNative = Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT;
+
     private static final MaterialWidgetHandler.Styleable[] sHiddenStyleables = {
             MaterialWidgetHandler.Styleable.VIEW
     };
@@ -24,5 +28,14 @@ public class MaterialView extends View {
               MaterialWidgetHandler.hideStyleableAttributes(attrs, sHiddenStyleables), defStyle);
         MaterialWidgetHandler.restoreStyleableAttributes(sHiddenStyleables);
         MaterialWidgetHandler.init(this, attrs, defStyle, sHiddenStyleables);
+    }
+
+    @Override
+    public void setBackgroundResource(@DrawableRes int resId) {
+        if(sNative) {
+            super.setBackgroundResource(resId);
+        } else {
+            super.setBackground(MaterialWidgetHandler.getDrawable(this, resId));
+        }
     }
 }

--- a/MaterialLibrary/src/main/java/io/doist/material/widget/utils/MaterialWidgetHandler.java
+++ b/MaterialLibrary/src/main/java/io/doist/material/widget/utils/MaterialWidgetHandler.java
@@ -21,10 +21,10 @@ import io.doist.material.reflection.ReflectionUtils;
 import io.doist.material.res.MaterialResources;
 
 public class MaterialWidgetHandler {
-    private static final boolean SKIP = Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT;
+    private static final boolean sNative = Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT;
 
     public static AttributeSet hideStyleableAttributes(AttributeSet set, Styleable... styleables) {
-        if (SKIP) {
+        if (sNative) {
             return set;
         }
 
@@ -36,7 +36,7 @@ public class MaterialWidgetHandler {
     }
 
     public static void restoreStyleableAttributes(Styleable... styleables) {
-        if (SKIP) {
+        if (sNative) {
             return;
         }
 
@@ -45,9 +45,8 @@ public class MaterialWidgetHandler {
         }
     }
 
-    @SuppressWarnings("ConstantConditions")
     public static void init(View view, AttributeSet set, int defStyle, Styleable[] styleables) {
-        if (SKIP) {
+        if (sNative) {
             return;
         }
 
@@ -58,11 +57,20 @@ public class MaterialWidgetHandler {
         }
     }
 
+    public static Drawable getDrawable(View view, int resId) {
+        if (resId != 0) {
+            Context context = view.getContext();
+            return MaterialResources.getInstance(context, context.getResources()).getDrawable(resId);
+        } else {
+            return null;
+        }
+    }
+
     /**
      * Applies {@code android:theme} to {@code context} by wrapping it in a {@link ContextThemeWrapper}.
      */
     public static Context themifyContext(Context context, AttributeSet attrs) {
-        if (SKIP) {
+        if (sNative) {
             return context;
         }
 
@@ -266,14 +274,6 @@ public class MaterialWidgetHandler {
                 } finally {
                     ta.recycle();
                 }
-            }
-        },
-
-        POPUP_WINDOW("PopupWindow", "popupBackground") {
-            @Override
-            public void initAttributes(Context context, MaterialResources resources, View view, AttributeSet set,
-                                       int defStyle) {
-                // No support needed.
             }
         },
 


### PR DESCRIPTION
This PR adds tinting capabilities after the initial inflation (ie. initialization) by overriding a few key methods and using `MaterialResources` behind the scenes.

This is similar to AppCompat's current behavior.
