### PR TITLE
Fix preference icon for RTL

### DIFF
--- a/MaterialLibrary/src/main/res/layout-v17/preference_material.xml
+++ b/MaterialLibrary/src/main/res/layout-v17/preference_material.xml
@@ -29,11 +29,11 @@
 
     <ImageView
         android:id="@android:id/icon"
+        style="@style/preference_icon"
         android:layout_width="56dp"
         android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:maxHeight="56dp"
-        android:scaleType="fitStart" />
+        android:layout_gravity="center_vertical"
+        android:maxHeight="56dp" />
 
     <RelativeLayout
         android:layout_width="0dp"

--- a/MaterialLibrary/src/main/res/layout/preference_material.xml
+++ b/MaterialLibrary/src/main/res/layout/preference_material.xml
@@ -32,7 +32,7 @@
         style="@style/preference_icon"
         android:layout_width="56dp"
         android:layout_height="wrap_content"
-        android:layout_gravity="center"
+        android:layout_gravity="center_vertical"
         android:maxHeight="56dp" />
 
     <RelativeLayout

--- a/MaterialLibrary/src/main/res/layout/preference_material.xml
+++ b/MaterialLibrary/src/main/res/layout/preference_material.xml
@@ -29,11 +29,11 @@
 
     <ImageView
         android:id="@android:id/icon"
+        style="@style/preference_icon"
         android:layout_width="56dp"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:maxHeight="56dp"
-        android:scaleType="fitStart" />
+        android:maxHeight="56dp" />
 
     <RelativeLayout
         android:layout_width="0dp"

--- a/MaterialLibrary/src/main/res/values-ldrtl/styles_widgets.xml
+++ b/MaterialLibrary/src/main/res/values-ldrtl/styles_widgets.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="preference_icon">
+        <item name="android:scaleType">fitEnd</item>
+    </style>
+
+</resources>

--- a/MaterialLibrary/src/main/res/values/styles_widgets.xml
+++ b/MaterialLibrary/src/main/res/values/styles_widgets.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="preference_icon">
+        <item name="android:scaleType">fitStart</item>
+    </style>
+
+</resources>


### PR DESCRIPTION
Suddenly `fitStart` «…aligns the result to the left and top edges of dst.», which caused a problem in RTL. This small PR fixes it. 

